### PR TITLE
#115: Create Mongo indexes script and added a build rule to produce a DB RPM

### DIFF
--- a/core/client-test-support/BUCK
+++ b/core/client-test-support/BUCK
@@ -4,8 +4,10 @@ java_library(
     deps = [
         '//common/id:queue-triage-common-id',
         '//core/client:queue-triage-core-client',
+        '//lib:commons-lang3',
         '//lib/test:hamcrest-core',
         '//lib/test:hamcrest-library',
+        '//lib/test:jgiven-core',
     ],
     visibility = [
         '//core/client:test',

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchFailedMessageResponseMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchFailedMessageResponseMatcher.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.core.domain;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
@@ -88,14 +89,18 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
 
     @Override
     public void describeTo(Description description) {
-        description
-                .appendText("failedMessageId is ").appendDescriptionOf(failedMessageId)
-                .appendText(" jmsMessageId is ").appendDescriptionOf(jmsMessageId)
-                .appendText(" content is ").appendDescriptionOf(content)
-                .appendText(" broker is ").appendDescriptionOf(broker)
-                .appendText(" destination is ").appendDescriptionOf(destination)
-                .appendText(" sentDateTime is ").appendDescriptionOf(sentDateTime)
-                .appendText(" failedDateTime is ").appendDescriptionOf(failedDateTime)
-        ;
+        appendIfMatcherIsNotIsAnything("failedMessageId is ", failedMessageId, description);
+        appendIfMatcherIsNotIsAnything(" jmsMessageId is ", jmsMessageId, description);
+        appendIfMatcherIsNotIsAnything(" content is ", content, description);
+        appendIfMatcherIsNotIsAnything(" broker is ", broker, description);
+        appendIfMatcherIsNotIsAnything(" destination is ", destination, description);
+        appendIfMatcherIsNotIsAnything(" sentDateTime is ", sentDateTime, description);
+        appendIfMatcherIsNotIsAnything(" failedDateTime is ", failedDateTime, description);
+    }
+
+    private void appendIfMatcherIsNotIsAnything(String text, Matcher<?> fieldMatcher, Description description) {
+        if (!IsAnything.class.equals(fieldMatcher.getClass())) {
+            description.appendText(text).appendDescriptionOf(fieldMatcher);
+        }
     }
 }

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchRequestBuilderArgumentFormatter.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/SearchRequestBuilderArgumentFormatter.java
@@ -1,0 +1,57 @@
+package uk.gov.dwp.queue.triage.core.domain;
+
+import com.tngtech.jgiven.format.ArgumentFormatter;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.Operator;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.SearchFailedMessageRequestBuilder;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Optional;
+
+public class SearchRequestBuilderArgumentFormatter implements ArgumentFormatter<SearchFailedMessageRequestBuilder> {
+
+    @Override
+    public String format(SearchFailedMessageRequestBuilder builder, String... strings) {
+        try {
+            final Field operatorField = builder.getClass().getDeclaredField("operator");
+            operatorField.setAccessible(true);
+            final Operator operator = (Operator) operatorField.get(builder);
+            return ReflectionToStringBuilder.toString(
+                    builder,
+                    new SearchRequestBuilderToStringStyle(operator.name().toLowerCase())
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalArgumentException("Cannot obtain Field operator");
+        }
+
+    }
+
+    static class SearchRequestBuilderToStringStyle extends ToStringStyle {
+
+        public SearchRequestBuilderToStringStyle(String fieldSeperator) {
+            setUseClassName(false);
+            setUseIdentityHashCode(false);
+            setContentStart("with ");
+            setContentEnd("'");
+            setFieldNameValueSeparator(": '");
+            setFieldSeparator("' " + fieldSeperator + " with ");
+        }
+
+        @Override
+        public void append(StringBuffer buffer, String fieldName, Object value, Boolean fullDetail) {
+            if (value == null) {
+                return;
+            }
+            if (value instanceof Optional) {
+                ((Optional)value).ifPresent(o -> super.append(buffer, fieldName, o, fullDetail));
+                return;
+            } else if (value instanceof Collection && ((Collection)value).isEmpty()) {
+                return;
+            }
+            super.append(buffer, fieldName, value, fullDetail);
+        }
+
+    }
+}

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
@@ -23,6 +23,10 @@ public class SearchFailedMessageResponse {
     private final String content;
     private final Set<String> labels;
 
+    public static SearchFailedMessageResponseBuilder newSearchFailedMessageResponse() {
+        return new SearchFailedMessageResponseBuilder();
+    }
+
     private SearchFailedMessageResponse(@JsonProperty("failedMessageId") FailedMessageId failedMessageId,
                                         @JsonProperty("jmsMessageId") String jmsMessageId,
                                         @JsonProperty("broker") String broker,
@@ -73,8 +77,18 @@ public class SearchFailedMessageResponse {
         return labels;
     }
 
-    public static SearchFailedMessageResponseBuilder newSearchFailedMessageResponse() {
-        return new SearchFailedMessageResponseBuilder();
+    @Override
+    public String toString() {
+        return "SearchFailedMessageResponse{" +
+                "failedMessageId=" + failedMessageId +
+                ", jmsMessageId='" + jmsMessageId + '\'' +
+                ", broker='" + broker + '\'' +
+                ", destination=" + destination +
+                ", sentDateTime=" + sentDateTime +
+                ", lastFailedDateTime=" + lastFailedDateTime +
+                ", content='" + content + '\'' +
+                ", labels=" + labels +
+                '}';
     }
 
     public static class SearchFailedMessageResponseBuilder {

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
@@ -19,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.SearchFailedMessageRequestBuilder;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.core.domain.SearchRequestBuilderArgumentFormatter;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
 import javax.ws.rs.core.Response.Status;
@@ -42,7 +43,7 @@ public class SearchFailedMessageStage extends Stage<SearchFailedMessageStage> {
     @ExpectedScenarioState
     private ResponseEntity<Collection<SearchFailedMessageResponse>> searchResponse;
 
-    public SearchFailedMessageStage aSearchIsRequested(@Format(value = ReflectionArgumentFormatter.class, args = {"broker", "destination"}) SearchFailedMessageRequestBuilder requestBuilder) {
+    public SearchFailedMessageStage aSearchIsRequestedForFailedMessages(@Format(value = SearchRequestBuilderArgumentFormatter.class) SearchFailedMessageRequestBuilder requestBuilder) {
         searchResponse = testRestTemplate.exchange(
                 "/core/failed-message/search",
                 HttpMethod.POST,

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/delete/DeleteFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/delete/DeleteFailedMessageComponentTest.java
@@ -28,7 +28,7 @@ public class DeleteFailedMessageComponentTest extends BaseCoreComponentTest<Dele
                 .exists();
 
         when().theFailedMessageWithId$IsDeleted(failedMessageId);
-        searchFailedMessageStage.and().aSearchIsRequested(searchMatchingAllCriteria()
+        searchFailedMessageStage.and().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withBroker("broker-name")
                 .withDestination("queue-name")
         );

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
@@ -13,6 +13,7 @@ import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
 import java.util.Arrays;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
@@ -28,7 +29,7 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
     @Test
     public void searchByBrokerResultsNoResultsWhenNoFailedMessagesExist() {
 
-        when().aSearchIsRequested(searchMatchingAllCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withBroker("broker-name"));
 
         then().theSearchResultsContain(noResults());
@@ -43,14 +44,14 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
                 .withDestinationName("queue-name"))
                 .exists();
 
-        when().aSearchIsRequested(searchMatchingAllCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withBroker("broker-name")
                 .withDestination("another-queue")
         );
 
         then().theSearchResultsContain(noResults());
 
-        when().aSearchIsRequested(searchMatchingAllCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withBroker("broker-name")
                 .withDestination("queue-name")
         );
@@ -75,19 +76,19 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
                 .withDestinationName("queue-name"))
                 .exists();
 
-        when().aSearchIsRequested(searchMatchingAnyCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAnyCriteria()
                 .withBroker("some-broker")
                 .withDestination("another-queue")
         );
 
         then().theSearchResultsContain(noResults());
 
-        when().aSearchIsRequested(searchMatchingAnyCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAnyCriteria()
                 .withBroker("broker-name")
                 .withDestination("queue-name")
         );
 
-        then().theSearchResultsContain(contains(
+        then().theSearchResultsContain(containsInAnyOrder(
                 aFailedMessage().withFailedMessageId(equalTo(failedMessageId)),
                 aFailedMessage().withFailedMessageId(equalTo(anotherFailedMessageId))
         ));
@@ -103,7 +104,7 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
                 .withContent("Bodger and Badger")
                 .exists();
 
-        when().aSearchIsRequested(searchMatchingAllCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withContent("and")
         );
 
@@ -111,7 +112,7 @@ public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<Sear
                 aFailedMessage()
                         .withFailedMessageId(equalTo(failedMessageId))));
 
-        when().aSearchIsRequested(searchMatchingAllCriteria()
+        when().aSearchIsRequestedForFailedMessages(searchMatchingAllCriteria()
                 .withContent("Bananas")
         );
 

--- a/core/dao-mongo/BUCK
+++ b/core/dao-mongo/BUCK
@@ -1,3 +1,5 @@
+include_defs('//tools/rpm_build.def')
+
 java_library(
     name = "queue-triage-core-dao-mongo",
     srcs = glob(["src/main/java/**/*.java"]),
@@ -31,6 +33,11 @@ java_library(
 )
 
 export_file(
+    name = 'mongo-queue-triage-indexes.sh',
+    src  = 'src/main/resources/mongo-queue-triage-indexes.sh',
+)
+
+export_file(
     name = 'mongo-queue-triage-roles.sh',
     src  = 'src/main/resources/mongo-queue-triage-roles.sh',
 )
@@ -40,9 +47,15 @@ export_file(
     src  = 'src/main/resources/mongo-queue-triage-users.sh',
 )
 
+mongo_cmd = [
+    '$(location :mongo-queue-triage-indexes.sh) > $OUT',
+    '$(location :mongo-queue-triage-roles.sh) >> $OUT',
+    '$(location :mongo-queue-triage-users.sh) >> $OUT'
+]
+
 genrule(
     name = 'create-users-and-roles',
-    cmd = '$(location :mongo-queue-triage-roles.sh) > $OUT && $(location :mongo-queue-triage-users.sh) >> $OUT',
+    cmd = ' && '.join(mongo_cmd),
     out = 'create-users-and-roles.log'
 )
 
@@ -68,5 +81,18 @@ java_test(
         '//lib/spring:spring-boot-with-dependencies',
         '//lib/spring:spring-test',
         '//lib/test:common',
+    ],
+)
+
+rpm_build(
+    name = 'rpm-build',
+    package_name = 'dwpuc-queue-triage-core-db',
+    rpm_prefix = 'queue-triage-core-db',
+    version = '1.0.0',
+    app_home = '/srv/app/mongo/queue-triage-core',
+    bin = [
+        '$(location :mongo-queue-triage-indexes.sh)',
+        '$(location :mongo-queue-triage-roles.sh)',
+        '$(location :mongo-queue-triage-users.sh)',
     ],
 )

--- a/core/dao-mongo/src/main/resources/mongo-queue-triage-indexes.sh
+++ b/core/dao-mongo/src/main/resources/mongo-queue-triage-indexes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+MONGO_DB_ADDRESS=${MONGO_DB_ADDRESS:-"localhost:27017/queue-triage"}
+MONGO_COLLECTION=${MONGO_COLLECTION:-"failedMessage"}
+MONGO_ADMIN_USER=${MONGO_ADMIN_USER:-"admin"}
+MONGO_ADMIN_PASSWORD=${MONGO_ADMIN_PASSWORD:-"Passw0rd"}
+MONGO_ADMIN_DB=${MONGO_ADMIN_DB:-"admin"}
+
+echo "Connecting to ${MONGO_DB_ADDRESS} as ${MONGO_ADMIN_USER}"
+
+mongo --username=${MONGO_ADMIN_USER} \
+      --password=${MONGO_ADMIN_PASSWORD} \
+      --authenticationDatabase=${MONGO_ADMIN_DB} \
+      ${MONGO_DB_ADDRESS} <<!
+db.getCollection("$MONGO_COLLECTION").createIndex({"statusHistory.0.status": 1, "destination.brokerName": 1})
+!

--- a/tools/rpm_build.def
+++ b/tools/rpm_build.def
@@ -4,36 +4,40 @@ def rpm_build(
         rpm_prefix,
         version,
         app_home,
-        lib  = []):
+        bin = [],
+        lib = []):
 
-    copy_libs_cmd = [
-        '$(exe //tools:copy_libs)',
-        '$OUT',
-    ] + lib
-    genrule(
-        name = 'copy_libs',
-        bash = ' '.join(copy_libs_cmd),
-        out =  '.',
-    )
+    fpm_cmd = [
+        'mkdir $TMP/fpm',
+    ]
+    if lib:
+        # Copy any files specified in the lib array (including expansion of classpath) to
+        # $BUCK_OUT/gen/$BUILD_PATH/copy_libs/lib
+        copy_libs_cmd = [
+            '$(exe //tools:copy_libs)',
+            '$OUT',
+        ] + lib
+        genrule(
+            name = 'copy_libs',
+            bash = ' '.join(copy_libs_cmd),
+            out =  '.',
+        )
+        # Copy all the files now in:
+        # $BUCK_OUT/gen/$BUILD_PATH/copy_libs/lib
+        # to
+        # $BUCK_OUT/gen/$BUILD_PATH/$NAME__tmp/fpm/lib
+        fpm_cmd += ['cp -R $(location :copy_libs)/lib $TMP/fpm']
 
-    cmd = [
-        'fpm',
-        '-C $(location :copy_libs)',
-        '-s dir',
-        '-t rpm',
-        '-n %s' % package_name,
-        '-p $OUT',
-        '--prefix %s' % app_home,
-        '-v %s' % version,
-        '--rpm-os LINUX',
-        '--rpm-user root',
-        '--rpm-group root',
-        '--epoch 1',
-        '--architecture noarch',
-        '.'
+    if bin:
+        fpm_cmd += ['mkdir -vp $TMP/fpm/bin']
+        for file in bin:
+            fpm_cmd += ['cp %s $TMP/fpm/bin' % file]
+
+    fpm_cmd += [
+        'fpm -C $TMP/fpm -s dir -t rpm -n %s -p $OUT --prefix %s -v %s --rpm-os LINUX --rpm-user root --rpm-group root --epoch 1 --architecture noarch .' % (package_name, app_home, version)
     ]
     genrule(
         name = name,
-        bash = ' '.join(cmd),
+        bash = ' && '.join(fpm_cmd),
         out  = '%s-%s.rpm' % (rpm_prefix, version),
     )


### PR DESCRIPTION
Added the following build rule to `core/dao-mongo/BUCK`:

```
rpm_build(
    name = 'rpm-build',
    package_name = 'dwpuc-queue-triage-core-db',
    rpm_prefix = 'queue-triage-core-db',
    version = '1.0.0',
    app_home = '/srv/app/mongo/queue-triage-core',
    bin = [
        '$(location :mongo-queue-triage-indexes.sh)',
        '$(location :mongo-queue-triage-roles.sh)',
        '$(location :mongo-queue-triage-users.sh)',
    ],
)
```
This creates an RPM `queue-triage-core-db-1.0.0.rpm` which contains the following files:

```
$ rpm -qilp buck-out/gen/core/dao-mongo/rpm-build/queue-triage-core-db-1.0.0.rpm 
Name        : dwpuc-queue-triage-core-db
Epoch       : 1
Version     : 1.0.0
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : default
Size        : 2307
License     : unknown
Signature   : (none)
Source RPM  : dwpuc-queue-triage-core-db-1.0.0-1.src.rpm
Build Date  : Mon 26 Feb 2018 21:10:44 AEST
Build Host  : localhost
Relocations : /srv/app/mongo/queue-triage-core 
Packager    : <andrewmcghie@localhost.localdomain>
Vendor      : andrewmcghie@localhost.localdomain
URL         : http://example.com/no-uri-given
Summary     : no description given
Description :
no description given
/srv/app/mongo/queue-triage-core/bin/mongo-queue-triage-indexes.sh
/srv/app/mongo/queue-triage-core/bin/mongo-queue-triage-roles.sh
/srv/app/mongo/queue-triage-core/bin/mongo-queue-triage-users.sh
```