### PR TITLE
#130: Update travis build file to perform a release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,11 @@ script:
   - ./gradlew createUsersAndRoles
   - ./gradlew build -Pselenium.remote_url=http://localhost:4444/wd/hub
 
+# Perform release with relevant credentials, and ignore checking if current branch is ahead of the remote, because travis will checkout in a detached head state.
 after_success:
-  - ./gradlew release -Prelease.customUsername=$RELEASE_CREDS_USERNAME -Prelease.customPassword=$RELEASE_CREDS_PASSWORD
+  - if [ ${TRAVIS_PULL_REQUEST} = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+    ./gradlew release -i -Prelease.customUsername=$RELEASE_CREDS_USERNAME -Prelease.customPassword=$RELEASE_CREDS_PASSWORD -Prelease.disableRemoteCheck;
+    fi;
 
 services:
   - mongodb

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'pl.allegro.tech.build.axion-release'
 scmVersion {
     tag {
         prefix = 'queue-triage'
+        initialVersion = { tag, position -> '1.0.0' }
+    }
+    repository {
+        pushTagsOnly = true
     }
 }
 


### PR DESCRIPTION
Update travis ci yml to push a release tag to the repo, when a build is triggered on master, and is not a pull request. 

Note: This has been tested against a forked master version, and the tagging occurs as expected.