### PR TITLE
Issue 107 - Duplicate message checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_script:
   - docker ps
 
 script:
-  - ./gradlew createUsersAndRoles
   - ./gradlew build -Pselenium.remote_url=http://localhost:4444/wd/hub
 
 # Perform release with relevant credentials, and ignore checking if current branch is ahead of the remote, because travis will checkout in a detached head state.

--- a/core/activemq/activemq.gradle
+++ b/core/activemq/activemq.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':common:cxf')
     implementation project(':common:executor')
+    implementation project(':common:id')
 
     implementation project(':core:domain')
     implementation project(':core:jms')

--- a/core/activemq/activemq.gradle
+++ b/core/activemq/activemq.gradle
@@ -7,18 +7,18 @@ dependencies {
     implementation project(':core:jms')
     implementation project(':core:service')
 
+    implementation 'com.google.guava:guava'
+    implementation 'io.swagger:swagger-annotations'
+    implementation 'javax.ws.rs:javax.ws.rs-api'
     implementation 'org.apache.activemq:activemq-client'
     implementation 'org.apache.geronimo.specs:geronimo-jms_1.1_spec'
-    implementation 'javax.ws.rs:javax.ws.rs-api'
     implementation 'org.slf4j:slf4j-api'
-
     implementation 'org.springframework.boot:spring-boot'
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
     implementation 'org.springframework:spring-beans'
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework:spring-core'
     implementation 'org.springframework:spring-jms'
-    implementation 'io.swagger:swagger-annotations'
 
 
     testImplementation project(':core:domain-test-support')

--- a/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/ActiveMQFailedMessageFactory.java
+++ b/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/ActiveMQFailedMessageFactory.java
@@ -41,6 +41,7 @@ public class ActiveMQFailedMessageFactory implements FailedMessageFactory {
                 .withSentDateTime(extractTimestamp(activeMQMessage.getTimestamp()))
                 .withFailedDateTime(extractTimestamp(activeMQMessage.getBrokerInTime()))
                 .withProperties(messagePropertyExtractor.extractProperties(message))
+                .withFailedMessageIdFromPropertyIfPresent()
                 .build();
     }
 

--- a/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResource.java
+++ b/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResource.java
@@ -17,7 +17,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
-import java.util.Map;
 import java.util.Optional;
 
 @Api(value = "Manage JMS Listeners")
@@ -43,9 +42,7 @@ public class MessageConsumerManagerResource {
             @ApiParam(value = "name of the broker as defined in application.yml", required = true)
             @PathParam("brokerName") String brokerName) {
         LOGGER.info("Starting consuming messages of the {} broker", brokerName);
-        messageConsumerManagerRegistry.get(brokerName)
-                .orElseThrow(NotFoundException::new)
-                .start();
+        getMessageConsumerManager(brokerName).start();
     }
 
     @ApiOperation("Stop consuming messages from the DLQ on the given broker")
@@ -59,9 +56,7 @@ public class MessageConsumerManagerResource {
             @ApiParam(value = "name of the broker as defined in application.yml", required = true)
             @PathParam("brokerName") String brokerName) {
         LOGGER.info("Stopping consuming messages of the {} broker", brokerName);
-        messageConsumerManagerRegistry.get(brokerName)
-                .orElseThrow(NotFoundException::new)
-                .stop();
+        getMessageConsumerManager(brokerName).stop();
     }
 
     @ApiOperation("Check the status of DLQ consumption on the given broker")
@@ -74,9 +69,12 @@ public class MessageConsumerManagerResource {
     public String isRunning(
             @ApiParam(value = "name of the broker as defined in application.yml", required = true)
             @PathParam("brokerName") String brokerName) {
-        return Boolean.toString(messageConsumerManagerRegistry.get(brokerName)
-                .orElseThrow(NotFoundException::new)
-                .isRunning());
+        return Boolean.toString(getMessageConsumerManager(brokerName).isRunning());
+    }
+
+    private MessageConsumerManager getMessageConsumerManager(@ApiParam(value = "name of the broker as defined in application.yml", required = true) @PathParam("brokerName") String brokerName) {
+        return messageConsumerManagerRegistry.get(brokerName)
+                .orElseThrow(NotFoundException::new);
     }
 
     @ApiOperation("Read all messages on the DLQ for the given broker.  This operation is only supported if the queue on the given broker is in read-only mode")

--- a/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResource.java
+++ b/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResource.java
@@ -7,12 +7,18 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.core.jms.activemq.browser.QueueBrowserScheduledExecutorService;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Optional;
 
 @Api(value = "Manage JMS Listeners")
 @Path("/admin/jms-listener")
@@ -71,5 +77,28 @@ public class MessageConsumerManagerResource {
         return Boolean.toString(messageConsumerManagerRegistry.get(brokerName)
                 .orElseThrow(NotFoundException::new)
                 .isRunning());
+    }
+
+    @ApiOperation("Read all messages on the DLQ for the given broker.  This operation is only supported if the queue on the given broker is in read-only mode")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "Queue Browser executed successfully"),
+            @ApiResponse(code = 404, message = "brokerName not found"),
+            @ApiResponse(code = 501, message = "Broker does not support this operation")
+    })
+    @PUT
+    @Path("/read-messages/{brokerName}")
+    public void readMessages(
+            @ApiParam(value = "name of the broker as defined in application.yml", required = true)
+            @PathParam("brokerName") String brokerName) {
+        final Optional<MessageConsumerManager> messageListenerManager = messageConsumerManagerRegistry.get(brokerName);
+        if (messageListenerManager.isPresent()) {
+            messageListenerManager
+                    .filter(QueueBrowserScheduledExecutorService.class::isInstance)
+                    .map(QueueBrowserScheduledExecutorService.class::cast)
+                    .orElseThrow(() -> new ServerErrorException(Response.Status.NOT_IMPLEMENTED))
+                    .execute();
+        } else {
+            throw new NotFoundException();
+        }
     }
 }

--- a/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/FailedMessageListenerBeanDefinitionFactory.java
+++ b/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/FailedMessageListenerBeanDefinitionFactory.java
@@ -20,7 +20,7 @@ public class FailedMessageListenerBeanDefinitionFactory {
     public AbstractBeanDefinition create(String brokerName) {
         return genericBeanDefinition(FailedMessageListener.class)
                 .addConstructorArgValue(activeMQFailedMessageFactoryFactory.apply(brokerName))
-                .addConstructorArgReference("failedMessageService")
+                .addConstructorArgReference("failedMessageProcessor")
                 .getBeanDefinition();
     }
 

--- a/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/NamedMessageListenerContainerBeanDefinitionFactory.java
+++ b/core/activemq/src/main/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/NamedMessageListenerContainerBeanDefinitionFactory.java
@@ -1,17 +1,21 @@
 package uk.gov.dwp.queue.triage.core.jms.activemq.spring;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 public class NamedMessageListenerContainerBeanDefinitionFactory {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NamedMessageListenerContainerBeanDefinitionFactory.class);
     public static final String NAMED_MESSAGE_LISTENER_CONTAINER_BEAN_NAME_PREFIX = "namedMessageListenerContainer-";
 
     public AbstractBeanDefinition create(String brokerName,
                                          String connectionFactoryBeanName,
                                          String queueName,
                                          String failedMessageListenerBeanName) {
+        LOGGER.debug("Creating NamedMessageListenerContainer BeanDefinition for {}", brokerName);
         return genericBeanDefinition(NamedMessageListenerContainer.class)
                 .addConstructorArgValue(brokerName)
                 .addPropertyReference("connectionFactory", connectionFactoryBeanName)

--- a/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/ActiveMQFailedMessageFactoryTest.java
+++ b/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/ActiveMQFailedMessageFactoryTest.java
@@ -1,46 +1,67 @@
 package uk.gov.dwp.queue.triage.core.jms.activemq;
 
 import org.apache.activemq.command.ActiveMQMessage;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.jms.DestinationExtractor;
 import uk.gov.dwp.queue.triage.core.jms.MessagePropertyExtractor;
 import uk.gov.dwp.queue.triage.core.jms.MessageTextExtractor;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
 
 import static java.time.Instant.now;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.dwp.queue.triage.core.domain.DestinationMatcher.aDestination;
 import static uk.gov.dwp.queue.triage.core.domain.FailedMessageMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.FAILED_MESSAGE_ID;
 
 public class ActiveMQFailedMessageFactoryTest {
 
     private static final Instant NOW = now();
-
-    private final MessageTextExtractor messageTextExtractor = mock(MessageTextExtractor.class);
-    private final DestinationExtractor destinationExtractor = mock(DestinationExtractor.class);
-    private final MessagePropertyExtractor messagePropertyExtractor = mock(MessagePropertyExtractor.class);
-
-    private final ActiveMQFailedMessageFactory underTest = new ActiveMQFailedMessageFactory(messageTextExtractor, destinationExtractor, messagePropertyExtractor);
-    private final ActiveMQMessage message = mock(ActiveMQMessage.class);
+    private static final String JMS_MESSAGE_ID = "ID:localhost.localdomain-46765-1518703251379-5:1:1:1:1";
+    private static final FailedMessageId FAILED_MESSAGE_ID_VALUE = FailedMessageId.newFailedMessageId();
+    private static final String MESSAGE_CONTENT = "Some text";
 
     @Rule
     public ExpectedException expectedException = none();
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private MessageTextExtractor messageTextExtractor;
+    @Mock
+    private DestinationExtractor<ActiveMQMessage> destinationExtractor;
+    @Mock
+    private MessagePropertyExtractor messagePropertyExtractor;
+    @Mock
+    private ActiveMQMessage message;
+    
+    private ActiveMQFailedMessageFactory underTest;
 
+    @Before
+    public void setUp() {
+        underTest = new ActiveMQFailedMessageFactory(messageTextExtractor, destinationExtractor, messagePropertyExtractor);
+    }
+    
     @Test
     public void exceptionIsThrownIfMessageIsNull() throws JMSException {
         expectedException.expect(IllegalArgumentException.class);
@@ -58,250 +79,272 @@ public class ActiveMQFailedMessageFactoryTest {
 
 
     @Test
-    public void createAFailedMessage() throws Exception {
+    public void createAFailedMessage() throws JMSException {
 
-        when(messageTextExtractor.extractText(message)).thenReturn("Some text");
+        when(messageTextExtractor.extractText(message)).thenReturn(MESSAGE_CONTENT);
         when(destinationExtractor.extractDestination(message)).thenReturn(new Destination("broker.name", of("queue.name")));
         when(messagePropertyExtractor.extractProperties(message)).thenReturn(emptyMap());
-        when(message.getJMSMessageID()).thenReturn("ID:localhost.localdomain-46765-1518703251379-5:1:1:1:1");
+        when(message.getJMSMessageID()).thenReturn(JMS_MESSAGE_ID);
         when(message.getTimestamp()).thenReturn(NOW.minusSeconds(5).toEpochMilli());
         when(message.getBrokerInTime()).thenReturn(NOW.toEpochMilli());
 
         FailedMessage failedMessage = underTest.createFailedMessage(message);
 
         assertThat(failedMessage, is(aFailedMessage()
-                .withJmsMessageId(equalTo("ID:localhost.localdomain-46765-1518703251379-5:1:1:1:1"))
-                .withContent(equalTo("Some text"))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withContent(equalTo(MESSAGE_CONTENT))
                 .withDestination(aDestination().withBrokerName("broker.name").withName("queue.name"))
                 .withSentAt(equalTo(NOW.minusSeconds(5)))
                 .withFailedAt(equalTo(NOW))
                 .withProperties(equalTo(emptyMap()))));
     }
 
+    @Test
+    public void createAFailedMessageWithFailedMessageIdFromProperty() throws JMSException {
+        final Map<String, Object> messageProperties = singletonMap(FAILED_MESSAGE_ID, FAILED_MESSAGE_ID_VALUE.toString());
+        when(messageTextExtractor.extractText(message)).thenReturn(MESSAGE_CONTENT);
+        when(destinationExtractor.extractDestination(message)).thenReturn(new Destination("broker.name", of("queue.name")));
+        when(messagePropertyExtractor.extractProperties(message)).thenReturn(messageProperties);
+        when(message.getJMSMessageID()).thenReturn(JMS_MESSAGE_ID);
+        when(message.getTimestamp()).thenReturn(NOW.minusSeconds(5).toEpochMilli());
+        when(message.getBrokerInTime()).thenReturn(NOW.toEpochMilli());
+
+        FailedMessage failedMessage = underTest.createFailedMessage(message);
+
+        assertThat(failedMessage, is(aFailedMessage()
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID_VALUE))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withContent(equalTo(MESSAGE_CONTENT))
+                .withDestination(aDestination().withBrokerName("broker.name").withName("queue.name"))
+                .withSentAt(equalTo(NOW.minusSeconds(5)))
+                .withFailedAt(equalTo(NOW))
+                .withProperties(equalTo(messageProperties))));
+    }
+
     static class SomeMessage implements Message {
 
         @Override
-        public String getJMSMessageID() throws JMSException {
+        public String getJMSMessageID() {
             return null;
         }
 
         @Override
-        public void setJMSMessageID(String id) throws JMSException {
+        public void setJMSMessageID(String id) {
 
         }
 
         @Override
-        public long getJMSTimestamp() throws JMSException {
+        public long getJMSTimestamp() {
             return 0;
         }
 
         @Override
-        public void setJMSTimestamp(long timestamp) throws JMSException {
+        public void setJMSTimestamp(long timestamp) {
 
         }
 
         @Override
-        public byte[] getJMSCorrelationIDAsBytes() throws JMSException {
+        public byte[] getJMSCorrelationIDAsBytes() {
             return new byte[0];
         }
 
         @Override
-        public void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException {
+        public void setJMSCorrelationIDAsBytes(byte[] correlationID) {
 
         }
 
         @Override
-        public void setJMSCorrelationID(String correlationID) throws JMSException {
+        public void setJMSCorrelationID(String correlationID) {
 
         }
 
         @Override
-        public String getJMSCorrelationID() throws JMSException {
+        public String getJMSCorrelationID() {
             return null;
         }
 
         @Override
-        public javax.jms.Destination getJMSReplyTo() throws JMSException {
+        public javax.jms.Destination getJMSReplyTo() {
             return null;
         }
 
         @Override
-        public void setJMSReplyTo(javax.jms.Destination replyTo) throws JMSException {
+        public void setJMSReplyTo(javax.jms.Destination replyTo) {
 
         }
 
         @Override
-        public javax.jms.Destination getJMSDestination() throws JMSException {
+        public javax.jms.Destination getJMSDestination() {
             return null;
         }
 
         @Override
-        public void setJMSDestination(javax.jms.Destination destination) throws JMSException {
+        public void setJMSDestination(javax.jms.Destination destination) {
 
         }
 
         @Override
-        public int getJMSDeliveryMode() throws JMSException {
+        public int getJMSDeliveryMode() {
             return 0;
         }
 
         @Override
-        public void setJMSDeliveryMode(int deliveryMode) throws JMSException {
+        public void setJMSDeliveryMode(int deliveryMode) {
 
         }
 
         @Override
-        public boolean getJMSRedelivered() throws JMSException {
+        public boolean getJMSRedelivered() {
             return false;
         }
 
         @Override
-        public void setJMSRedelivered(boolean redelivered) throws JMSException {
+        public void setJMSRedelivered(boolean redelivered) {
 
         }
 
         @Override
-        public String getJMSType() throws JMSException {
+        public String getJMSType() {
             return null;
         }
 
         @Override
-        public void setJMSType(String type) throws JMSException {
+        public void setJMSType(String type) {
 
         }
 
         @Override
-        public long getJMSExpiration() throws JMSException {
+        public long getJMSExpiration() {
             return 0;
         }
 
         @Override
-        public void setJMSExpiration(long expiration) throws JMSException {
+        public void setJMSExpiration(long expiration) {
 
         }
 
         @Override
-        public int getJMSPriority() throws JMSException {
+        public int getJMSPriority() {
             return 0;
         }
 
         @Override
-        public void setJMSPriority(int priority) throws JMSException {
+        public void setJMSPriority(int priority) {
 
         }
 
         @Override
-        public void clearProperties() throws JMSException {
+        public void clearProperties() {
 
         }
 
         @Override
-        public boolean propertyExists(String name) throws JMSException {
+        public boolean propertyExists(String name) {
             return false;
         }
 
         @Override
-        public boolean getBooleanProperty(String name) throws JMSException {
+        public boolean getBooleanProperty(String name) {
             return false;
         }
 
         @Override
-        public byte getByteProperty(String name) throws JMSException {
+        public byte getByteProperty(String name) {
             return 0;
         }
 
         @Override
-        public short getShortProperty(String name) throws JMSException {
+        public short getShortProperty(String name) {
             return 0;
         }
 
         @Override
-        public int getIntProperty(String name) throws JMSException {
+        public int getIntProperty(String name) {
             return 0;
         }
 
         @Override
-        public long getLongProperty(String name) throws JMSException {
+        public long getLongProperty(String name) {
             return 0;
         }
 
         @Override
-        public float getFloatProperty(String name) throws JMSException {
+        public float getFloatProperty(String name) {
             return 0;
         }
 
         @Override
-        public double getDoubleProperty(String name) throws JMSException {
+        public double getDoubleProperty(String name) {
             return 0;
         }
 
         @Override
-        public String getStringProperty(String name) throws JMSException {
+        public String getStringProperty(String name) {
             return null;
         }
 
         @Override
-        public Object getObjectProperty(String name) throws JMSException {
+        public Object getObjectProperty(String name) {
             return null;
         }
 
         @Override
-        public Enumeration getPropertyNames() throws JMSException {
+        public Enumeration getPropertyNames() {
             return null;
         }
 
         @Override
-        public void setBooleanProperty(String name, boolean value) throws JMSException {
+        public void setBooleanProperty(String name, boolean value) {
 
         }
 
         @Override
-        public void setByteProperty(String name, byte value) throws JMSException {
+        public void setByteProperty(String name, byte value) {
 
         }
 
         @Override
-        public void setShortProperty(String name, short value) throws JMSException {
+        public void setShortProperty(String name, short value) {
 
         }
 
         @Override
-        public void setIntProperty(String name, int value) throws JMSException {
+        public void setIntProperty(String name, int value) {
 
         }
 
         @Override
-        public void setLongProperty(String name, long value) throws JMSException {
+        public void setLongProperty(String name, long value) {
 
         }
 
         @Override
-        public void setFloatProperty(String name, float value) throws JMSException {
+        public void setFloatProperty(String name, float value) {
 
         }
 
         @Override
-        public void setDoubleProperty(String name, double value) throws JMSException {
+        public void setDoubleProperty(String name, double value) {
 
         }
 
         @Override
-        public void setStringProperty(String name, String value) throws JMSException {
+        public void setStringProperty(String name, String value) {
 
         }
 
         @Override
-        public void setObjectProperty(String name, Object value) throws JMSException {
+        public void setObjectProperty(String name, Object value) {
 
         }
 
         @Override
-        public void acknowledge() throws JMSException {
+        public void acknowledge() {
 
         }
 
         @Override
-        public void clearBody() throws JMSException {
+        public void clearBody() {
 
         }
     }

--- a/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResourceTest.java
+++ b/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/MessageConsumerManagerResourceTest.java
@@ -24,13 +24,13 @@ public class MessageConsumerManagerResourceTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private final MessageConsumerManager defaultMessageListenerContainer = mock(MessageListenerManager.class);
+    private final MessageConsumerManager defaultMessageListenerContainer = mock(MessageConsumerManager.class);
     private final QueueBrowserScheduledExecutorService queueBrowserScheduledExecutorService = mock(QueueBrowserScheduledExecutorService.class);
 
     private final MessageConsumerManagerResource underTest = new MessageConsumerManagerResource(
             new MessageConsumerManagerRegistry()
-                    .with("internal-broker", messageConsumerManager)
-                    .with("readonly-broker", messageConsumerManager)
+                    .with("internal-broker", defaultMessageListenerContainer)
+                    .with("readonly-broker", queueBrowserScheduledExecutorService)
 
     );
 
@@ -44,17 +44,17 @@ public class MessageConsumerManagerResourceTest {
     }
 
     @Test(expected = NotFoundException.class)
-    public void startThrowsANotFoundExceptionIfBrokerIsUnknown() throws Exception {
+    public void startThrowsANotFoundExceptionIfBrokerIsUnknown() {
         underTest.start("unknown-broker");
     }
 
     @Test(expected = NotFoundException.class)
-    public void stopThrowsANotFoundExceptionIfBrokerIsUnknown() throws Exception {
+    public void stopThrowsANotFoundExceptionIfBrokerIsUnknown() {
         underTest.stop("unknown-broker");
     }
 
     @Test
-    public void startDefaultMessageListenerContainer() throws Exception {
+    public void startDefaultMessageListenerContainer() {
         underTest.start("internal-broker");
 
         verify(defaultMessageListenerContainer).start();

--- a/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/BeanDefinitionFactoryTestBase.java
+++ b/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/BeanDefinitionFactoryTestBase.java
@@ -1,0 +1,69 @@
+package uk.gov.dwp.queue.triage.core.jms.activemq.spring;
+
+import org.junit.After;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import uk.gov.dwp.queue.triage.core.jms.activemq.configuration.JmsListenerConfig;
+import uk.gov.dwp.queue.triage.core.service.processor.FailedMessageProcessor;
+
+import java.util.Properties;
+
+import static org.mockito.Mockito.mock;
+
+public class BeanDefinitionFactoryTestBase {
+
+    AnnotationConfigApplicationContext applicationContext;
+
+    @After
+    public void tearDown() {
+        applicationContext.close();
+    }
+
+    protected void createApplicationContext(String yamlFilename) {
+        applicationContext = new AnnotationConfigApplicationContext();
+        applicationContext.setEnvironment(createEnvironment(yamlFilename));
+        applicationContext.register(JmsListenerConfig.class, AdditionalConfig.class);
+        applicationContext.refresh();
+    }
+
+    private StandardEnvironment createEnvironment(String yamlFilename) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new PropertiesPropertySource("broker-properties", loadPropertiesFromYaml(yamlFilename)));
+
+        return environment;
+    }
+
+    private Properties loadPropertiesFromYaml(String yamlFilename) {
+        YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+        yamlPropertiesFactoryBean.setResources(new ClassPathResource(yamlFilename));
+        return yamlPropertiesFactoryBean.getObject();
+    }
+
+    protected <T> T getBean(String beanName, Class<T> beanType) {
+        try {
+            return applicationContext.getBean(beanName, beanType);
+        } catch (NoSuchBeanDefinitionException e) {
+            return null;
+        }
+    }
+
+    protected int numberOfBeansOfType(Class<?> beanType) {
+        return applicationContext.getBeanNamesForType(beanType).length;
+    }
+
+    @Configuration
+    public static class AdditionalConfig {
+
+        @Bean
+        public FailedMessageProcessor failedMessageProcessor() {
+            return mock(FailedMessageProcessor.class);
+        }
+
+    }
+}

--- a/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/FailedMessageListenerBeanDefinitionFactoryTest.java
+++ b/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/FailedMessageListenerBeanDefinitionFactoryTest.java
@@ -23,17 +23,17 @@ public class FailedMessageListenerBeanDefinitionFactoryTest {
             new FailedMessageListenerBeanDefinitionFactory(brokerName -> activeMQFailedMessageFactory);
 
     @Test
-    public void createFailedMessageListenerBeanDefinition() throws Exception {
+    public void createFailedMessageListenerBeanDefinition() {
         AbstractBeanDefinition abstractBeanDefinition = underTest.create(BROKER_NAME);
 
         assertThat(abstractBeanDefinition.getBeanClass(), typeCompatibleWith(FailedMessageListener.class));
         assertThat(abstractBeanDefinition.getConstructorArgumentValues().getIndexedArgumentValues().size(), is(2));
         assertThat(abstractBeanDefinition.getConstructorArgumentValues().getArgumentValue(0, ActiveMQFailedMessageFactory.class).getValue(), is(activeMQFailedMessageFactory));
-        assertThat(abstractBeanDefinition.getConstructorArgumentValues().getArgumentValue(1, ActiveMQFailedMessageFactory.class).getValue(), is(equalTo(new RuntimeBeanReference("failedMessageService"))));
+        assertThat(abstractBeanDefinition.getConstructorArgumentValues().getArgumentValue(1, ActiveMQFailedMessageFactory.class).getValue(), is(equalTo(new RuntimeBeanReference("failedMessageProcessor"))));
     }
 
     @Test
-    public void createBeanName() throws Exception {
+    public void createBeanName() {
         assertThat(underTest.createBeanName(BROKER_NAME), is(equalTo(FAILED_MESSAGE_LISTENER_BEAN_NAME_PREFIX + BROKER_NAME)));
     }
 }

--- a/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/JmsBeanDefinitionRegistryPostProcessorTest.java
+++ b/core/activemq/src/test/java/uk/gov/dwp/queue/triage/core/jms/activemq/spring/JmsBeanDefinitionRegistryPostProcessorTest.java
@@ -16,7 +16,7 @@ import uk.gov.dwp.queue.triage.core.jms.FailedMessageListener;
 import uk.gov.dwp.queue.triage.core.jms.activemq.browser.QueueBrowserScheduledExecutorService;
 import uk.gov.dwp.queue.triage.core.jms.activemq.configuration.JmsListenerConfig;
 import uk.gov.dwp.queue.triage.core.jms.activemq.configuration.MessageConsumerApplicationInitializer;
-import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.core.service.processor.FailedMessageProcessor;
 
 import java.util.Properties;
 
@@ -114,7 +114,7 @@ public class JmsBeanDefinitionRegistryPostProcessorTest {
         return environment;
     }
 
-    public Properties loadPropertiesFromYaml(String yamlFilename) {
+    private Properties loadPropertiesFromYaml(String yamlFilename) {
         YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
         yamlPropertiesFactoryBean.setResources(new ClassPathResource(yamlFilename));
         return yamlPropertiesFactoryBean.getObject();
@@ -124,8 +124,8 @@ public class JmsBeanDefinitionRegistryPostProcessorTest {
     public static class AdditionalConfig {
 
         @Bean
-        public FailedMessageService failedMessageService() {
-            return mock(FailedMessageService.class);
+        public FailedMessageProcessor failedMessageProcessor() {
+            return mock(FailedMessageProcessor.class);
         }
 
     }

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestMatcher.java
@@ -1,11 +1,10 @@
-package uk.gov.dwp.queue.triage.core.domain;
+package uk.gov.dwp.queue.triage.core.client.search;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.Operator;
 
 import java.util.Optional;

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseMatcher.java
@@ -1,11 +1,9 @@
-package uk.gov.dwp.queue.triage.core.domain;
+package uk.gov.dwp.queue.triage.core.client.search;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -22,6 +20,7 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
     private Matcher<Optional<String>> destination = new IsAnything<>();
     private Matcher<Instant> sentDateTime = new IsAnything<>();
     private Matcher<Instant> failedDateTime = new IsAnything<>();
+    private Matcher<Iterable<? extends String>> labels = new IsAnything<>();
 
     private SearchFailedMessageResponseMatcher() {
     }
@@ -75,6 +74,11 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
         return this;
     }
 
+    public SearchFailedMessageResponseMatcher withLabels(Matcher<Iterable<? extends String>> labelsMatcher) {
+        this.labels = labelsMatcher;
+        return this;
+    }
+
     @Override
     protected boolean matchesSafely(SearchFailedMessageResponse item) {
         return failedMessageId.matches(item.getFailedMessageId())
@@ -84,6 +88,7 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
                 && destination.matches(item.getDestination())
                 && sentDateTime.matches(item.getSentDateTime())
                 && failedDateTime.matches(item.getLastFailedDateTime())
+                && labels.matches(item.getLabels())
                 ;
     }
 
@@ -96,6 +101,7 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
         appendIfMatcherIsNotIsAnything(" destination is ", destination, description);
         appendIfMatcherIsNotIsAnything(" sentDateTime is ", sentDateTime, description);
         appendIfMatcherIsNotIsAnything(" failedDateTime is ", failedDateTime, description);
+        appendIfMatcherIsNotIsAnything(" labels is ", labels, description);
     }
 
     private void appendIfMatcherIsNotIsAnything(String text, Matcher<?> fieldMatcher, Description description) {

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchRequestBuilderArgumentFormatter.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchRequestBuilderArgumentFormatter.java
@@ -1,4 +1,4 @@
-package uk.gov.dwp.queue.triage.core.domain;
+package uk.gov.dwp.queue.triage.core.client.search;
 
 import com.tngtech.jgiven.format.ArgumentFormatter;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageRequestTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.FAILED;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
 
 public class SearchFailedMessageRequestTest {
 

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
@@ -10,6 +10,7 @@ import org.springframework.jms.core.JmsTemplate;
 import uk.gov.dwp.queue.triage.core.classification.MessageClassifier;
 import uk.gov.dwp.queue.triage.core.classification.action.FailedMessageAction;
 import uk.gov.dwp.queue.triage.core.classification.predicate.ContentEqualToPredicate;
+import uk.gov.dwp.queue.triage.core.jms.TextMessageBuilder;
 import uk.gov.dwp.queue.triage.core.stub.app.resource.StubMessageClassifierResource;
 
 import java.util.concurrent.TimeUnit;
@@ -54,6 +55,11 @@ public class JmsStage extends Stage<JmsStage> {
 
     public JmsStage aMessageWithContent$IsSentTo$OnBroker$(String content, String destination, String brokerName) {
         dummyAppJmsTemplate.send(destination, session -> session.createTextMessage(content));
+        return this;
+    }
+
+    public JmsStage aMessage$IsSentTo$OnBroker$(TextMessageBuilder textMessageBuilder, String destination, String broker) {
+        dummyAppJmsTemplate.send(destination, session -> textMessageBuilder.build(session));
         return this;
     }
 

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminStage.java
@@ -1,13 +1,12 @@
 package uk.gov.dwp.queue.triage.core.jms;
 
 import com.tngtech.jgiven.Stage;
-import com.tngtech.jgiven.annotation.ExpectedScenarioState;
 import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.format.BooleanFormatter;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 
 import javax.ws.rs.core.Response;
@@ -20,33 +19,19 @@ public class FailedMessageListenerAdminStage extends Stage<FailedMessageListener
 
     @Autowired
     private TestRestTemplate testRestTemplate;
-    @ExpectedScenarioState
+    @ProvidedScenarioState
     private ResponseEntity<?> response;
 
     public FailedMessageListenerAdminStage theMessageListenerFor$Is$Running(String brokerName,
                                                                             @Format(value = BooleanFormatter.class, args = {"", "not"}) boolean isRunning) {
-        aRequestIsMadeToGetTheStatusOfTheMessageListenerForBroker$(brokerName);
-        assertThat(response.getBody(), is(isRunning));
-        return this;
-    }
-
-    public FailedMessageListenerAdminStage aRequestIsMadeToStopTheMessageListenerForBroker$(String brokerName) {
-        response = new FailedMessageListenerFixture(testRestTemplate).stopListenerForBroker(brokerName);
-        return this;
-    }
-
-    public FailedMessageListenerAdminStage aRequestIsMadeToStartTheMessageListenerForBroker$(String brokerName) {
-        response = new FailedMessageListenerFixture(testRestTemplate).startListenerForBroker(brokerName);
+        assertThat(new FailedMessageListenerFixture(testRestTemplate)
+                .statusOfListenerForBroker(brokerName)
+                .getBody(), is(isRunning));
         return this;
     }
 
     public FailedMessageListenerAdminStage theMessageListenerAdminResourceRespondsWith$StatusCode(Response.Status status) {
         assertThat(response.getStatusCodeValue(), is(status.getStatusCode()));
-        return this;
-    }
-
-    public FailedMessageListenerAdminStage aRequestIsMadeToGetTheStatusOfTheMessageListenerForBroker$(String brokerName) {
-        response = new FailedMessageListenerFixture(testRestTemplate).statusOfListenerForBroker(brokerName);
         return this;
     }
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminWhenStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerAdminWhenStage.java
@@ -1,0 +1,37 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import uk.gov.dwp.queue.triage.jgiven.WhenStage;
+
+@JGivenStage
+public class FailedMessageListenerAdminWhenStage extends WhenStage<FailedMessageListenerAdminWhenStage> {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    @ExpectedScenarioState
+    private ResponseEntity<?> response;
+
+    public FailedMessageListenerAdminWhenStage aRequestIsMadeToStopTheMessageListenerForBroker$(String brokerName) {
+        response = new FailedMessageListenerFixture(testRestTemplate).stopListenerForBroker(brokerName);
+        return this;
+    }
+
+    public FailedMessageListenerAdminWhenStage aRequestIsMadeToStartTheMessageListenerForBroker$(String brokerName) {
+        response = new FailedMessageListenerFixture(testRestTemplate).startListenerForBroker(brokerName);
+        return this;
+    }
+
+    public FailedMessageListenerAdminWhenStage aRequestIsMadeToGetTheStatusOfTheMessageListenerForBroker$(String brokerName) {
+        response = new FailedMessageListenerFixture(testRestTemplate).statusOfListenerForBroker(brokerName);
+        return this;
+    }
+
+    public FailedMessageListenerAdminWhenStage theMesageListenerReadsMessagesOnBroker$(String brokerName) {
+        new FailedMessageListenerFixture(testRestTemplate).readMessagesForBroker(brokerName);
+        return self();
+    }
+}

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerFixture.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerFixture.java
@@ -37,4 +37,12 @@ public class FailedMessageListenerFixture {
                 brokerName);
     }
 
+    public void readMessagesForBroker(String brokerName) {
+        testRestTemplate.put(
+                "/core/admin/jms-listener/read-messages/{brokerName}",
+                null,
+                brokerName
+        );
+    }
+
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/TextMessageBuilder.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/jms/TextMessageBuilder.java
@@ -1,0 +1,52 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TextMessageBuilder {
+
+    private String content;
+    private Map<String, Object> properties = new HashMap<>();
+
+    public TextMessageBuilder withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public TextMessageBuilder withProperty(String key, Object value) {
+        if (properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, value);
+        return this;
+    }
+
+    public TextMessageBuilder withProperties(Map<String, Object> properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    public TextMessage build(Session session) throws JMSException {
+        final TextMessage textMessage = session.createTextMessage(content);
+        if (properties != null) {
+            for (String key : properties.keySet()) {
+                textMessage.setObjectProperty(key, properties.get(key));
+            }
+        }
+        return textMessage;
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder("with content '")
+                .append(content).append("'");
+        if (!properties.isEmpty()) {
+            for (String key : properties.keySet()) {
+                sb.append(" and property ").append(key).append(" '").append(properties.get(key)).append("'");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageStage.java
@@ -19,7 +19,8 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.SearchFailedMessageRequestBuilder;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.core.domain.SearchRequestBuilderArgumentFormatter;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher;
+import uk.gov.dwp.queue.triage.core.client.search.SearchRequestBuilderArgumentFormatter;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
 import javax.ws.rs.core.Response.Status;
@@ -28,6 +29,8 @@ import java.util.Collection;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.is;
 
 @JGivenStage
@@ -64,6 +67,23 @@ public class SearchFailedMessageStage extends Stage<SearchFailedMessageStage> {
     ) {
         await().pollInterval(100, MILLISECONDS)
                 .until(() -> doSearch(requestBuilder), resultsMatcher);
+        return this;
+    }
+
+    public SearchFailedMessageStage aSearch$ContainsNoResults(
+            @Format(value = ReflectionArgumentFormatter.class, args = {"broker", "destination"}) SearchFailedMessageRequestBuilder requestBuilder
+    ) {
+        await().pollInterval(100, MILLISECONDS)
+                .until(() -> doSearch(requestBuilder), emptyIterable());
+        return this;
+    }
+
+    public SearchFailedMessageStage aSearch$WillContainAResponseWhere$(
+            @Format(value = ReflectionArgumentFormatter.class, args = {"broker", "destination"}) SearchFailedMessageRequestBuilder requestBuilder,
+            SearchFailedMessageResponseMatcher responseMatcher
+    ) {
+        await().pollInterval(100, MILLISECONDS)
+                .until(() -> doSearch(requestBuilder), contains(responseMatcher));
         return this;
     }
 

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
@@ -1,6 +1,6 @@
 package uk.gov.dwp.queue.triage.core.stub.app.configuration;
 
-import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.pool.PooledConnectionFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,36 +54,36 @@ public class StubAppJmsConfiguration {
     }
 
     @Bean(destroyMethod = "shutdown")
-    public DefaultMessageListenerContainer dummyAppMessageListenerContainer(JmsListenerProperties jmsListenerProperties,
+    public DefaultMessageListenerContainer dummyAppMessageListenerContainer(ConnectionFactory dummyAppConnectionFactory,
                                                                             MessageListener stubMessageListener) {
-        ConnectionFactory connectionFactory = createConnectionFactory(jmsListenerProperties, BROKER_NAME);
         DefaultMessageListenerContainer defaultMessageListenerContainer = new DefaultMessageListenerContainer();
-        defaultMessageListenerContainer.setConnectionFactory(connectionFactory);
+        defaultMessageListenerContainer.setConnectionFactory(dummyAppConnectionFactory);
         defaultMessageListenerContainer.setDestinationName("some-queue");
         defaultMessageListenerContainer.setMessageListener(stubMessageListener);
-        defaultMessageListenerContainer.setTransactionManager(new JmsTransactionManager(connectionFactory));
+        defaultMessageListenerContainer.setTransactionManager(new JmsTransactionManager(dummyAppConnectionFactory));
         defaultMessageListenerContainer.setSessionTransacted(true);
         return defaultMessageListenerContainer;
     }
 
     @Bean
-    public JmsTemplate dummyAppJmsTemplate(JmsListenerProperties jmsListenerProperties) {
-        JmsTemplate jmsTemplate = new JmsTemplate(createConnectionFactory(jmsListenerProperties, BROKER_NAME));
+    public JmsTemplate dummyAppJmsTemplate(ConnectionFactory dummyAppConnectionFactory) {
+        JmsTemplate jmsTemplate = new JmsTemplate(dummyAppConnectionFactory);
         jmsTemplate.setDeliveryPersistent(true);
         return jmsTemplate;
     }
 
-    private ConnectionFactory createConnectionFactory(JmsListenerProperties jmsListenerProperties, String brokerName) {
+    @Bean
+    public ConnectionFactory dummyAppConnectionFactory(JmsListenerProperties jmsListenerProperties) {
         JmsListenerProperties.BrokerProperties brokerProperties = jmsListenerProperties
                 .getBrokers()
                 .stream()
-                .filter(broker -> brokerName.equalsIgnoreCase(broker.getName()))
+                .filter(broker -> BROKER_NAME.equalsIgnoreCase(broker.getName()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Cannot find configuration for " + brokerName));
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find configuration for " + BROKER_NAME));
         String brokerUrl = brokerProperties.getUrl();
         brokerUrl += (brokerUrl.contains("?") ? "&" : "?");
         brokerUrl += "jms.redeliveryPolicy.maximumRedeliveries=0";
-        return new ActiveMQConnectionFactory(brokerUrl);
+        return new PooledConnectionFactory(brokerUrl);
     }
 
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
@@ -1,6 +1,6 @@
 package uk.gov.dwp.queue.triage.core.stub.app.configuration;
 
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.ActiveMQConnectionFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -83,7 +83,7 @@ public class StubAppJmsConfiguration {
         String brokerUrl = brokerProperties.getUrl();
         brokerUrl += (brokerUrl.contains("?") ? "&" : "?");
         brokerUrl += "jms.redeliveryPolicy.maximumRedeliveries=0";
-        return new PooledConnectionFactory(brokerUrl);
+        return new ActiveMQConnectionFactory(brokerUrl);
     }
 
 }

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/classification/ClassifyFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/classification/ClassifyFailedMessageComponentTest.java
@@ -14,8 +14,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
-import static uk.gov.dwp.queue.triage.core.jms.FailedMessageListenerComponentTest.contains;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
 import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
 
 public class ClassifyFailedMessageComponentTest extends BaseCoreComponentTest<JmsStage> {
@@ -54,11 +53,11 @@ public class ClassifyFailedMessageComponentTest extends BaseCoreComponentTest<Jm
 
         messageClassificationWhenStage.when().theMessageClassificationJobExecutes();
 
-        searchFailedMessageStage.then().aSearch$WillContain$(
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
                 searchMatchingAllCriteria().withBroker("some-broker"),
-                contains(aFailedMessage()
+                aFailedMessage()
                         .withFailedMessageId(equalTo(failedMessageId))
-                        .withContent(equalTo("nuts")))
+                        .withContent(equalTo("nuts"))
         );
     }
 
@@ -83,9 +82,9 @@ public class ClassifyFailedMessageComponentTest extends BaseCoreComponentTest<Jm
 
         messageClassificationWhenStage.when().theMessageClassificationJobExecutes();
 
-        searchFailedMessageStage.then().aSearch$WillContain$(
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
                 searchMatchingAllCriteria().withDestination("some-queue"),
-                contains(aFailedMessage().withFailedMessageId(equalTo(failedMessageId)))
+                aFailedMessage().withFailedMessageId(equalTo(failedMessageId))
         );
     }
 

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageConsumerManagerComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageConsumerManagerComponentTest.java
@@ -20,6 +20,8 @@ public class FailedMessageConsumerManagerComponentTest extends BaseCoreComponent
     @ScenarioStage
     private JmsStage jmsStage;
     @ScenarioStage
+    private FailedMessageListenerAdminWhenStage messageListenerAdminWhenStage;
+    @ScenarioStage
     private SearchFailedMessageStage searchFailedMessageStage;
 
     @Test
@@ -27,7 +29,7 @@ public class FailedMessageConsumerManagerComponentTest extends BaseCoreComponent
         jmsStage.given().aMessageWithContent$WillDeadLetter("poison");
         given().theMessageListenerFor$Is$Running("internal-broker", true);
 
-        when().aRequestIsMadeToStopTheMessageListenerForBroker$("internal-broker");
+        messageListenerAdminWhenStage.when().aRequestIsMadeToStopTheMessageListenerForBroker$("internal-broker");
         then().theMessageListenerFor$Is$Running("internal-broker", false);
         jmsStage.when().aMessageWithContent$IsSentTo$OnBroker$("poison", "some-queue", "internal-broker");
 
@@ -35,7 +37,7 @@ public class FailedMessageConsumerManagerComponentTest extends BaseCoreComponent
                 searchMatchingAllCriteria().withBroker("internal-broker"),
                 Matchers.emptyIterable()
         );
-        when().aRequestIsMadeToStartTheMessageListenerForBroker$("internal-broker");
+        messageListenerAdminWhenStage.when().aRequestIsMadeToStartTheMessageListenerForBroker$("internal-broker");
 
         then().theMessageListenerFor$Is$Running("internal-broker", true);
         searchFailedMessageStage.then().aSearch$WillContain$(
@@ -49,19 +51,19 @@ public class FailedMessageConsumerManagerComponentTest extends BaseCoreComponent
 
     @Test
     public void startingABrokerThatDoesNotExistReturnsNotFound() {
-        when().aRequestIsMadeToStartTheMessageListenerForBroker$("unknown-broker");
+        messageListenerAdminWhenStage.when().aRequestIsMadeToStartTheMessageListenerForBroker$("unknown-broker");
         then().theMessageListenerAdminResourceRespondsWith$StatusCode(NOT_FOUND);
     }
 
     @Test
     public void stoppingABrokerThatDoesNotExistReturnsNotFound() {
-        when().aRequestIsMadeToStopTheMessageListenerForBroker$("unknown-broker");
+        messageListenerAdminWhenStage.when().aRequestIsMadeToStopTheMessageListenerForBroker$("unknown-broker");
         then().theMessageListenerAdminResourceRespondsWith$StatusCode(NOT_FOUND);
     }
 
     @Test
     public void gettingTheStatusOfABrokerThatDoesNotExistReturnsNotFound() {
-        when().aRequestIsMadeToGetTheStatusOfTheMessageListenerForBroker$("unknown-broker");
+        messageListenerAdminWhenStage.when().aRequestIsMadeToGetTheStatusOfTheMessageListenerForBroker$("unknown-broker");
         then().theMessageListenerAdminResourceRespondsWith$StatusCode(NOT_FOUND);
     }
 }

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerComponentTest.java
@@ -6,21 +6,27 @@ import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
+import uk.gov.dwp.queue.triage.core.FailedMessageResourceStage;
 import uk.gov.dwp.queue.triage.core.JmsStage;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
 import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.FAILED_MESSAGE_ID;
 
 public class FailedMessageListenerComponentTest extends BaseCoreComponentTest<JmsStage> {
 
+    @ScenarioStage
+    private FailedMessageResourceStage failedMessageResourceStage;
     @ScenarioStage
     private SearchFailedMessageStage searchFailedMessageStage;
 
@@ -32,14 +38,44 @@ public class FailedMessageListenerComponentTest extends BaseCoreComponentTest<Jm
         when().aMessageWithContent$IsSentTo$OnBroker$("poison", "some-queue", "internal-broker");
         when().and().aMessageWithContent$IsSentTo$OnBroker$("elixir", "some-queue", "internal-broker");
 
-        searchFailedMessageStage.then().aSearch$WillContain$(
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
                 searchMatchingAllCriteria().withBroker("internal-broker"),
-                contains(aFailedMessage()
+                aFailedMessage()
                         .withBroker(equalTo("internal-broker"))
                         .withDestination(equalTo(Optional.of("some-queue")))
                         .withContent(equalTo("poison"))
                         .withJmsMessageId(Matchers.notNullValue(String.class))
-        ));
+        );
+    }
+
+    @Test
+    public void existingFailedMessageIsUpdatedIfItDeadLettersAgain() {
+        final FailedMessageId failedMessageId = FailedMessageId.newFailedMessageId();
+        failedMessageResourceStage.given().aFailedMessage(newCreateFailedMessageRequest()
+                .withFailedMessageId(failedMessageId)
+                .withBrokerName("internal-broker")
+                .withDestinationName("some-queue")
+                .withContent("some content")
+                .withLabel("foo")
+        ).exists();
+        given().and().aMessageWithContent$WillDeadLetter("poison");
+
+        when().aMessage$IsSentTo$OnBroker$(new TextMessageBuilder()
+                .withContent("poison")
+                .withProperty(FAILED_MESSAGE_ID, failedMessageId.toString()),
+                "some-queue",
+                "internal-broker"
+        );
+
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
+                searchMatchingAllCriteria().withBroker("internal-broker"),
+                aFailedMessage()
+                        .withBroker(equalTo("internal-broker"))
+                        .withDestination(equalTo(Optional.of("some-queue")))
+                        .withContent(equalTo("poison"))
+                        .withJmsMessageId(Matchers.notNullValue(String.class))
+                        .withLabels(Matchers.contains("foo"))
+        );
     }
 
     public static Matcher<Iterable<? extends SearchFailedMessageResponse>> contains(SearchFailedMessageResponseMatcher... searchResultMatcher) {

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/ReadOnlyFailedMessageListenerComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/ReadOnlyFailedMessageListenerComponentTest.java
@@ -48,7 +48,7 @@ public class ReadOnlyFailedMessageListenerComponentTest extends BaseCoreComponen
                         .withDestination(equalTo(Optional.of("some-queue")))
                         .withContent(equalTo("poison"))
         ));
-        then().and().deadLetterQueueContains$Messages(1);
+        then().and().deadLetterQueueStillContains$Messages(1);
     }
 
     @Test

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/ReadOnlyFailedMessageListenerComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/jms/ReadOnlyFailedMessageListenerComponentTest.java
@@ -1,23 +1,17 @@
 package uk.gov.dwp.queue.triage.core.jms;
 
 import com.tngtech.jgiven.annotation.ScenarioStage;
-import org.hamcrest.Matcher;
-import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
 import uk.gov.dwp.queue.triage.core.JmsStage;
-import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage;
-import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
 
 @ActiveProfiles(value = "read-only-component-test", inheritProfiles = false)
 public class ReadOnlyFailedMessageListenerComponentTest extends BaseCoreComponentTest<JmsStage> {
@@ -41,13 +35,13 @@ public class ReadOnlyFailedMessageListenerComponentTest extends BaseCoreComponen
 
         messageListenerAdminWhenStage.when().theMesageListenerReadsMessagesOnBroker$("internal-broker");
 
-        searchFailedMessageStage.then().aSearch$WillContain$(
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
                 searchMatchingAllCriteria().withBroker("internal-broker"),
-                contains(aFailedMessage()
+                aFailedMessage()
                         .withBroker(equalTo("internal-broker"))
                         .withDestination(equalTo(Optional.of("some-queue")))
                         .withContent(equalTo("poison"))
-        ));
+        );
         then().and().deadLetterQueueStillContains$Messages(1);
     }
 
@@ -62,22 +56,13 @@ public class ReadOnlyFailedMessageListenerComponentTest extends BaseCoreComponen
         messageListenerAdminWhenStage.when().and().theMesageListenerReadsMessagesOnBroker$("internal-broker");
         messageListenerAdminWhenStage.when().and().theMesageListenerReadsMessagesOnBroker$("internal-broker");
 
-        searchFailedMessageStage.then().aSearch$WillContain$(
+        searchFailedMessageStage.then().aSearch$WillContainAResponseWhere$(
                 searchMatchingAllCriteria().withBroker("internal-broker"),
-                contains(aFailedMessage()
+                aFailedMessage()
                         .withBroker(equalTo("internal-broker"))
                         .withDestination(equalTo(Optional.of("some-queue")))
                         .withContent(equalTo("poison"))
-                ));
+                );
         then().and().deadLetterQueueContains$Messages(1);
-    }
-
-    public static Matcher<Iterable<? extends SearchFailedMessageResponse>> contains(SearchFailedMessageResponseMatcher... searchResultMatcher) {
-        return new IsIterableContainingInOrder<SearchFailedMessageResponse>(Arrays.asList(searchResultMatcher)) {
-            @Override
-            public String toString() {
-                return "a message " + new ReflectionArgumentFormatter().format(searchResultMatcher, "broker", "destination");
-            }
-        };
     }
 }

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageComponentTest.java
@@ -31,7 +31,7 @@ public class ResendFailedMessageComponentTest extends BaseCoreComponentTest<JmsS
     private JmsStage jmsStage;
 
     @Test
-    public void markMessageForResending() throws Exception {
+    public void markMessageForResending() {
         FailedMessageId failedMessageId = FailedMessageId.newFailedMessageId();
         FailedMessageId failedMessageIdToResend = newFailedMessageId();
 

--- a/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
+++ b/core/component-test/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageComponentTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.BaseCoreComponentTest;
 import uk.gov.dwp.queue.triage.core.FailedMessageResourceStage;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
-import uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAnyCriteria;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
 import static uk.gov.dwp.queue.triage.core.search.SearchFailedMessageStage.noResults;
 
 public class SearchFailedMessageComponentTest extends BaseCoreComponentTest<SearchFailedMessageStage> {

--- a/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
+++ b/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
@@ -8,6 +8,7 @@ import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.mongo.spring.MongoSearchConfiguration;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
 import uk.gov.dwp.queue.triage.core.service.processor.DisregardingFailedMessageProcessor;
+import uk.gov.dwp.queue.triage.core.service.processor.ExistingFailedMessageProcessor;
 import uk.gov.dwp.queue.triage.core.service.processor.PredicateOutcomeFailedMessageProcessor;
 import uk.gov.dwp.queue.triage.core.service.processor.UniqueFailedMessageIdPredicate;
 import uk.gov.dwp.queue.triage.core.service.processor.UniqueJmsMessageIdPredicate;
@@ -28,7 +29,7 @@ public class FailedMessageProcessorConfiguration {
                 new PredicateOutcomeFailedMessageProcessor(
                         new UniqueFailedMessageIdPredicate(failedMessageDao),
                         failedMessageService::create,
-                        new DisregardingFailedMessageProcessor(failedMessage -> "is not unique, disregarding for now.")
+                        new ExistingFailedMessageProcessor(failedMessageDao)
                 ),
                 new DisregardingFailedMessageProcessor(failedMessage -> "with JMSMessageId=" + failedMessage.getJmsMessageId() + " is not unique")
         );

--- a/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
+++ b/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
@@ -1,0 +1,36 @@
+package uk.gov.dwp.queue.triage.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+import uk.gov.dwp.queue.triage.core.search.mongo.spring.MongoSearchConfiguration;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.core.service.processor.DisregardingFailedMessageProcessor;
+import uk.gov.dwp.queue.triage.core.service.processor.PredicateOutcomeFailedMessageProcessor;
+import uk.gov.dwp.queue.triage.core.service.processor.UniqueFailedMessageIdPredicate;
+import uk.gov.dwp.queue.triage.core.service.processor.UniqueJmsMessageIdPredicate;
+
+@Configuration
+@Import({
+        FailedMessageServiceConfiguration.class,
+        MongoSearchConfiguration.class
+})
+public class FailedMessageProcessorConfiguration {
+
+    @Bean
+    public PredicateOutcomeFailedMessageProcessor failedMessageProcessor(FailedMessageSearchService failedMessageSearchService,
+                                                                         FailedMessageService failedMessageService,
+                                                                         FailedMessageDao failedMessageDao) {
+        return new PredicateOutcomeFailedMessageProcessor(
+                new UniqueJmsMessageIdPredicate(failedMessageSearchService),
+                new PredicateOutcomeFailedMessageProcessor(
+                        new UniqueFailedMessageIdPredicate(failedMessageDao),
+                        failedMessageService::create,
+                        new DisregardingFailedMessageProcessor(failedMessage -> "is not unique, disregarding for now.")
+                ),
+                new DisregardingFailedMessageProcessor(failedMessage -> "with JMSMessageId=" + failedMessage.getJmsMessageId() + " is not unique")
+        );
+    }
+}

--- a/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResource.java
+++ b/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageSearchResource.java
@@ -6,6 +6,7 @@ import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
@@ -15,6 +16,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
 
 public class FailedMessageSearchResource implements SearchFailedMessageClient {
 
@@ -36,7 +38,7 @@ public class FailedMessageSearchResource implements SearchFailedMessageClient {
     @Override
     public FailedMessageResponse getFailedMessage(FailedMessageId failedMessageId) {
         FailedMessage failedMessage = failedMessageDao.findById(failedMessageId);
-        if (failedMessage == null) {
+        if ((failedMessage == null) || (DELETED.equals(failedMessage.getStatus()))) {
             throw new NotFoundException(format("Failed Message: %s not found", failedMessageId));
         }
         return failedMessageResponseFactory.create(failedMessage);

--- a/core/dao-mongo/dao-mongo.gradle
+++ b/core/dao-mongo/dao-mongo.gradle
@@ -44,14 +44,22 @@ distributions {
     }
 }
 
-task createUsersAndRoles(dependsOn: installDist) {
-    doLast {
-        FileTree listOfScripts = fileTree(dir: "${project.projectDir}/build/install/dao-mongo", include: "**/*.sh")
-        listOfScripts.sort().each { file ->
-            println "Executing script: $file"
-            exec {
-                commandLine file
-            }    
-        }
-    }
+task createMongoRoles(type: Exec) {
+    workingDir './src/main/resources'
+
+    commandLine './mongo-queue-triage-roles.sh'
 }
+
+task createMongoUsers(type: Exec) {
+    workingDir './src/main/resources'
+
+    commandLine './mongo-queue-triage-users.sh'
+}
+
+task createMongoIndexes(type: Exec) {
+    workingDir './src/main/resources'
+
+    commandLine './mongo-queue-triage-indexes.sh'
+}
+
+tasks.test.dependsOn createMongoRoles, createMongoUsers, createMongoIndexes

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageConverter.java
@@ -118,6 +118,15 @@ public class FailedMessageConverter implements DBObjectWithIdConverter<FailedMes
                 ;
     }
 
+    public BasicDBObject convertForUpdate(FailedMessage item) {
+        return new BasicDBObject()
+                .append(JMS_MESSAGE_ID, item.getJmsMessageId())
+                .append(DESTINATION, destinationDBObjectMapper.convertFromObject(item.getDestination()))
+                .append(CONTENT, item.getContent())
+                .append(PROPERTIES, propertiesMongoMapper.convertFromObject(item.getProperties()))
+                ;
+    }
+
     @Override
     public BasicDBObject createId(FailedMessageId failedMessageId) {
         return new BasicDBObject("_id", failedMessageId.getId().toString());

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
@@ -82,10 +82,7 @@ public class FailedMessageMongoDao implements FailedMessageDao {
 
     @Override
     public FailedMessage findById(FailedMessageId failedMessageId) {
-        DBObject failedMessage = collection.findOne(failedMessageConverter
-                .createId(failedMessageId)
-                .append(STATUS_HISTORY + ".0." + STATUS, new BasicDBObject(QueryOperators.NE, DELETED.name())));
-        return failedMessageConverter.convertToObject(failedMessage);
+        return failedMessageConverter.convertToObject(collection.findOne(failedMessageConverter.createId(failedMessageId)));
     }
 
     @Override

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDao.java
@@ -4,7 +4,6 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
-import com.mongodb.QueryOperators;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
 import com.mongodb.operation.OrderBy;
@@ -25,8 +24,6 @@ import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.DEST
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.LABELS;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter.STATUS_HISTORY;
 import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.LAST_MODIFIED_DATE_TIME;
-import static uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageStatusDBObjectConverter.STATUS;
-import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.DELETED;
 
 public class FailedMessageMongoDao implements FailedMessageDao {
 
@@ -59,6 +56,19 @@ public class FailedMessageMongoDao implements FailedMessageDao {
     }
 
     @Override
+    public void update(FailedMessage failedMessage) {
+        collection.update(
+                failedMessageConverter.createId(failedMessage.getFailedMessageId()),
+                new BasicDBObject()
+                        .append("$push", new BasicDBObject(STATUS_HISTORY, new BasicDBObject()
+                                .append("$each", singletonList(failedMessageStatusConverter.convertFromObject(failedMessage.getStatusHistoryEvent())))
+                                .append("$sort", new BasicDBObject(LAST_MODIFIED_DATE_TIME, OrderBy.DESC.getIntRepresentation()))))
+                        .append("$set", failedMessageConverter.convertForUpdate(failedMessage)),
+                NO_UPSERT, SINGLE_ROW, WriteConcern.ACKNOWLEDGED
+        );
+    }
+
+    @Override
     public void updateStatus(FailedMessageId failedMessageId, StatusHistoryEvent statusHistoryEvent) {
         collection.update(
                 failedMessageConverter.createId(failedMessageId),
@@ -71,7 +81,7 @@ public class FailedMessageMongoDao implements FailedMessageDao {
 
     @Override
     public List<StatusHistoryEvent> getStatusHistory(FailedMessageId failedMessageId) {
-        return ((BasicDBList)collection
+        return ((BasicDBList) collection
                 .findOne(failedMessageConverter.createId(failedMessageId), new BasicDBObject(STATUS_HISTORY, 1))
                 .get(STATUS_HISTORY))
                 .stream()

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/FailedMessageMongoDaoTest.java
@@ -59,15 +59,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void findFailedMessageWithDeletedStatusReturnsNull() {
-
-        underTest.insert(failedMessageBuilder.withStatusHistoryEvent(DELETED).build());
-
-        assertThat(underTest.findById(failedMessageId), is(nullValue(FailedMessage.class)));
-    }
-
-    @Test
-    public void saveMessageWithEmptyPropertiesAndNoLabels() throws Exception {
+    public void saveMessageWithEmptyPropertiesAndNoLabels() {
         failedMessageBuilder.withProperties(emptyMap());
 
         underTest.insert(failedMessageBuilder.build());
@@ -82,7 +74,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void saveMessageWithPropertiesAndLabels() throws Exception {
+    public void saveMessageWithPropertiesAndLabels() {
         HashMapBuilder<String, Object> hashMapBuilder = newHashMap(String.class, Object.class)
                 .put("string", "Builder")
                 .put("localDateTime", LocalDateTime.now())
@@ -110,7 +102,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void findNumberOfMessagesForBroker() throws Exception {
+    public void findNumberOfMessagesForBroker() {
         underTest.insert(failedMessageBuilder
                 .withNewFailedMessageId()
                 .withDestination(new Destination("brokerA", of("queue-name")))
@@ -124,7 +116,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void findNumberOfMessagesForBrokerReturnsZeroWhenNoneExist() throws Exception {
+    public void findNumberOfMessagesForBrokerReturnsZeroWhenNoneExist() {
         underTest.insert(failedMessageBuilder
                 .withNewFailedMessageId()
                 .withDestination(new Destination("brokerB", of("queue-name")))
@@ -198,7 +190,7 @@ public class FailedMessageMongoDaoTest extends AbstractMongoDaoTest {
     }
 
     @Test
-    public void setLabelsOnAFailedMessageReplacesExistingLabels() throws Exception {
+    public void setLabelsOnAFailedMessageReplacesExistingLabels() {
         underTest.insert(failedMessageBuilder.withLabel("something").build());
 
         underTest.setLabels(failedMessageId, ImmutableSet.of("foo", "bar"));

--- a/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
+++ b/core/dao/src/main/java/uk/gov/dwp/queue/triage/core/dao/FailedMessageDao.java
@@ -15,6 +15,8 @@ public interface FailedMessageDao {
 
     long findNumberOfMessagesForBroker(String broker);
 
+    void update(FailedMessage failedMessage);
+
     void updateStatus(FailedMessageId failedMessageId, StatusHistoryEvent statusHistoryEvent);
 
     List<StatusHistoryEvent> getStatusHistory(FailedMessageId failedMessageId);

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessage.java
@@ -84,4 +84,8 @@ public class FailedMessage {
     public StatusHistoryEvent getStatusHistoryEvent() {
         return statusHistoryEvent;
     }
+
+    public StatusHistoryEvent.Status getStatus() {
+        return statusHistoryEvent.getStatus();
+    }
 }

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageBuilder.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class FailedMessageBuilder {
@@ -108,6 +109,14 @@ public class FailedMessageBuilder {
 
     public FailedMessageBuilder withLabel(String label) {
         labels.add(label);
+        return this;
+    }
+
+    public FailedMessageBuilder withFailedMessageIdFromPropertyIfPresent() {
+        Optional.ofNullable(properties.get("failedMessageId"))
+                .map(String.class::cast)
+                .map(FailedMessageId::fromString)
+                .ifPresent(this::withFailedMessageId);
         return this;
     }
 }

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
@@ -6,27 +6,29 @@ import org.slf4j.LoggerFactory;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class FailedMessageStatusAdapter {
+public final class FailedMessageStatusAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageStatusAdapter.class);
 
-    private static Map<Status, FailedMessageStatus> statusToFailedMessageStatus = new HashMap<Status, FailedMessageStatus>() {{
-        put(Status.FAILED, FailedMessageStatus.FAILED);
-        put(Status.CLASSIFIED, FailedMessageStatus.FAILED);
-        put(Status.RESEND, FailedMessageStatus.RESENDING);
-        put(Status.SENT, FailedMessageStatus.SENT);
-    }};
+    private static Map<Status, FailedMessageStatus> statusToFailedMessageStatus = new HashMap<>();
+    private static Map<FailedMessageStatus, Set<Status>> failedMessageStatusToStatusMapping = new EnumMap<>(FailedMessageStatus.class);
 
-    private static Map<FailedMessageStatus, Set<Status>> failedMessageStatusToStatusMapping = new HashMap<FailedMessageStatus, Set<Status>>() {{
-        put(FailedMessageStatus.FAILED, Sets.immutableEnumSet(Status.FAILED, Status.CLASSIFIED));
-        put(FailedMessageStatus.RESENDING, Sets.immutableEnumSet(Status.RESEND));
-        put(FailedMessageStatus.SENT, Sets.immutableEnumSet(Status.SENT));
-    }};
+    static {
+        statusToFailedMessageStatus.put(Status.FAILED, FailedMessageStatus.FAILED);
+        statusToFailedMessageStatus.put(Status.CLASSIFIED, FailedMessageStatus.FAILED);
+        statusToFailedMessageStatus.put(Status.RESEND, FailedMessageStatus.RESENDING);
+        statusToFailedMessageStatus.put(Status.SENT, FailedMessageStatus.SENT);
+
+        failedMessageStatusToStatusMapping.put(FailedMessageStatus.FAILED, Sets.immutableEnumSet(Status.FAILED, Status.CLASSIFIED));
+        failedMessageStatusToStatusMapping.put(FailedMessageStatus.RESENDING, Sets.immutableEnumSet(Status.RESEND));
+        failedMessageStatusToStatusMapping.put(FailedMessageStatus.SENT, Sets.immutableEnumSet(Status.SENT));
+    }
 
 
     public static FailedMessageStatus toFailedMessageStatus(Status status) {

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/StatusHistoryEvent.java
@@ -5,15 +5,15 @@ import java.time.Instant;
 public class StatusHistoryEvent {
 
     private final Status status;
-    private final Instant effectiveDateTimme;
+    private final Instant effectiveDateTime;
 
     public static StatusHistoryEvent statusHistoryEvent(Status status) {
         return new StatusHistoryEvent(status, Instant.now());
     }
 
-    public StatusHistoryEvent(Status status, Instant effectiveDateTimme) {
+    public StatusHistoryEvent(Status status, Instant effectiveDateTime) {
         this.status = status;
-        this.effectiveDateTimme = effectiveDateTimme;
+        this.effectiveDateTime = effectiveDateTime;
     }
 
     public Status getStatus() {
@@ -21,7 +21,15 @@ public class StatusHistoryEvent {
     }
 
     public Instant getEffectiveDateTime() {
-        return effectiveDateTimme;
+        return effectiveDateTime;
+    }
+
+    @Override
+    public String toString() {
+        return "StatusHistoryEvent{" +
+                "status=" + status +
+                ", effectiveDateTime=" + effectiveDateTime +
+                '}';
     }
 
     public enum Status {

--- a/core/jms/jms.gradle
+++ b/core/jms/jms.gradle
@@ -10,6 +10,7 @@ dependencies{
 
 
     //TEST
+    testImplementation 'com.google.guava:guava'
     testImplementation 'org.apache.commons:commons-lang3'
     testImplementation 'org.springframework:spring-tx'
     // this was test:common

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProvider.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProvider.java
@@ -20,7 +20,6 @@ public class FailedMessageDataProvider implements JmsMessageDataProvider<TextMes
             try {
                 textMessage.setObjectProperty(key, properties.get(key));
             } catch (JMSException ignore) {
-                // TODO: Should we just ignore the fact we couldn't set a property on the message?
                 LOGGER.warn("Could not add property: '{}' when sending FailedMessage: {}", key, data.getFailedMessageId());
             }
         });

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProvider.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProvider.java
@@ -1,0 +1,29 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+import java.util.Map;
+
+public class FailedMessageDataProvider implements JmsMessageDataProvider<TextMessage, FailedMessage> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageDataProvider.class);
+    @Override
+    public void provide(TextMessage textMessage, FailedMessage data) throws JMSException {
+        textMessage.setText(data.getContent());
+        Map<String, Object> properties = data.getProperties();
+        properties.keySet().forEach(key -> {
+            try {
+                textMessage.setObjectProperty(key, properties.get(key));
+            } catch (JMSException ignore) {
+                // TODO: Should we just ignore the fact we couldn't set a property on the message?
+                LOGGER.warn("Could not add property: '{}' when sending FailedMessage: {}", key, data.getFailedMessageId());
+            }
+        });
+        textMessage.setStringProperty(FailedMessageId.FAILED_MESSAGE_ID, data.getFailedMessageId().toString());
+    }
+}

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageDataProvider.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageDataProvider.java
@@ -1,0 +1,9 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+public interface JmsMessageDataProvider<M extends Message, T> {
+    void provide(M jmsMessage, T data) throws JMSException;
+}

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreator.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreator.java
@@ -1,43 +1,33 @@
 package uk.gov.dwp.queue.triage.core.jms.spring;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.jms.core.MessageCreator;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.jms.FailedMessageDataProvider;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
 
 public class FailedMessageCreator implements MessageCreator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageCreator.class);
-
     private final FailedMessage failedMessage;
+    private final List<FailedMessageDataProvider> failedMessageDataProviders;
 
     public FailedMessageCreator(FailedMessage failedMessage) {
         this.failedMessage = failedMessage;
+        this.failedMessageDataProviders = Collections.singletonList(new FailedMessageDataProvider());
     }
 
     @Override
     public Message createMessage(Session session) throws JMSException {
         TextMessage textMessage = session.createTextMessage();
-        textMessage.setText(failedMessage.getContent());
-        Map<String, Object> properties = failedMessage.getProperties();
-        properties.keySet().forEach(key -> {
-            try {
-                textMessage.setObjectProperty(key, properties.get(key));
-            } catch (JMSException ignore) {
-                // TODO: Should we just ignore the fact we couldn't set a property on the message?
-                LOGGER.warn("Could not add property: '{}' when sending FailedMessage: {}", key, failedMessage.getFailedMessageId());
-            }
-        });
+        for (FailedMessageDataProvider failedMessageDataProvider : failedMessageDataProviders) {
+            failedMessageDataProvider.provide(textMessage, failedMessage);
+        }
         return textMessage;
     }
 
-    public interface FailedMessageCreatorFactory {
-        FailedMessageCreator create(FailedMessage failedMessage);
-    }
 }

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreatorFactory.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreatorFactory.java
@@ -1,0 +1,8 @@
+package uk.gov.dwp.queue.triage.core.jms.spring;
+
+import org.springframework.jms.core.MessageCreator;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+public interface FailedMessageCreatorFactory {
+    MessageCreator create(FailedMessage failedMessage);
+}

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/SpringMessageSender.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/SpringMessageSender.java
@@ -6,7 +6,6 @@ import org.springframework.jms.core.JmsTemplate;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 import uk.gov.dwp.queue.triage.core.jms.DestinationException;
 import uk.gov.dwp.queue.triage.core.jms.MessageSender;
-import uk.gov.dwp.queue.triage.core.jms.spring.FailedMessageCreator.FailedMessageCreatorFactory;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.util.function.Supplier;

--- a/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProviderTest.java
+++ b/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageDataProviderTest.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FailedMessageDataProviderTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+    private final TextMessage textMessage = mock(TextMessage.class);
+
+    private final FailedMessageDataProvider underTest = new FailedMessageDataProvider();
+
+    @Test
+    public void processingContinuesObjectPropertyCannotBeWritten() throws JMSException {
+        when(failedMessage.getContent()).thenReturn("content");
+        when(failedMessage.getProperties()).thenReturn(ImmutableMap.of("foo", "bar", "ham", "eggs"));
+        when(failedMessage.getFailedMessageId()).thenReturn(FAILED_MESSAGE_ID);
+        doThrow(new JMSException("Arrrghhhhh")).when(textMessage).setObjectProperty("foo", "bar");
+
+        underTest.provide(textMessage, failedMessage);
+
+        verify(textMessage).setText("content");
+        verify(textMessage).setObjectProperty("foo", "bar");
+        verify(textMessage).setObjectProperty("ham", "eggs");
+        verify(textMessage).setStringProperty(FailedMessageId.FAILED_MESSAGE_ID, FAILED_MESSAGE_ID.toString());
+    }
+}

--- a/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerTest.java
+++ b/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageListenerTest.java
@@ -2,7 +2,7 @@ package uk.gov.dwp.queue.triage.core.jms;
 
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.core.service.processor.FailedMessageProcessor;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -15,12 +15,12 @@ import static org.mockito.Mockito.when;
 public class FailedMessageListenerTest {
 
     private final FailedMessageFactory failedMessageFactory = mock(FailedMessageFactory.class);
-    private final FailedMessageService failedMessageService = mock(FailedMessageService.class);
+    private final FailedMessageProcessor failedMessageProcessor = mock(FailedMessageProcessor.class);
 
     private final Message message = mock(Message.class);
     private final FailedMessage failedMessage = mock(FailedMessage.class);
 
-    private final FailedMessageListener underTest = new FailedMessageListener(failedMessageFactory, failedMessageService);
+    private final FailedMessageListener underTest = new FailedMessageListener(failedMessageFactory, failedMessageProcessor);
 
     @Test
     public void processMessageSuccessfully() throws Exception {
@@ -28,7 +28,7 @@ public class FailedMessageListenerTest {
 
         underTest.onMessage(message);
 
-        verify(failedMessageService).create(failedMessage);
+        verify(failedMessageProcessor).process(failedMessage);
     }
 
     @Test
@@ -37,6 +37,6 @@ public class FailedMessageListenerTest {
 
         underTest.onMessage(message);
 
-        verifyZeroInteractions(failedMessageService);
+        verifyZeroInteractions(failedMessageProcessor);
     }
 }

--- a/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/executor/MessageClassificationExecutorServiceTest.java
+++ b/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/server/executor/MessageClassificationExecutorServiceTest.java
@@ -43,7 +43,7 @@ public class MessageClassificationExecutorServiceTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         LOGGER.debug("Shutting down the scheduledExecutorService");
         scheduledExecutorService.shutdownNow();
     }
@@ -109,6 +109,13 @@ public class MessageClassificationExecutorServiceTest {
 
         underTest.execute();
         verifyMessageClassificationServiceExecutions(0);
+    }
+
+    @Test
+    public void executorCanBeStopped() {
+        underTest.stop();
+
+        assertThat(scheduledExecutorService.isShutdown(), is(true));
     }
 
     private Answer decrementCountdownLatch() {

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResource.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResource.java
@@ -49,9 +49,6 @@ public class ResendScheduledExecutorsResource {
     }
 
     private ResendScheduledExecutorService getExecutor(String brokerName) {
-        if (brokerName == null) {
-            throw new BadRequestException("A broker must be specified");
-        }
         ResendScheduledExecutorService resendScheduledExecutorService = resendScheduledExecutors.get(brokerName);
         if (resendScheduledExecutorService == null) {
             throw new BadRequestException("Cannot find a ResendScheduledExecutorService for broker: " + brokerName);

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageServiceTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendFailedMessageServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.RESENDING;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
 
 public class ResendFailedMessageServiceTest {
 

--- a/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResourceTest.java
+++ b/core/resend/src/test/java/uk/gov/dwp/queue/triage/core/resend/ResendScheduledExecutorsResourceTest.java
@@ -1,0 +1,112 @@
+package uk.gov.dwp.queue.triage.core.resend;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.Variant;
+import javax.ws.rs.ext.RuntimeDelegate;
+import java.util.HashMap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ResendScheduledExecutorsResourceTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final ResendScheduledExecutorService resendScheduledExecutorService = mock(ResendScheduledExecutorService.class);
+
+    private final ResendScheduledExecutorsResource underTest = new ResendScheduledExecutorsResource(
+            new HashMap<String, ResendScheduledExecutorService>() {{
+                put("internal-broker", resendScheduledExecutorService);
+            }}
+    );
+
+    static {
+        System.setProperty("javax.ws.rs.ext.RuntimeDelegate", StubRuntimeDelegate.class.getName());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void startThrowsABadRequestExceptionIfBrokerIsUnknown() {
+        underTest.start("unknown-broker");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void executeThrowsABadRequestExceptionIfBrokerIsUnknown() {
+        underTest.execute("unknown-broker");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void pauseThrowsABadRequestExceptionIfBrokerIsUnknown() {
+        underTest.pause("unknown-broker");
+    }
+
+    @Test
+    public void startResendScheduledExecutorService() {
+        underTest.start("internal-broker");
+
+        verify(resendScheduledExecutorService).start();
+    }
+
+    @Test
+    public void executeResendScheduledExecutorService() {
+        underTest.execute("internal-broker");
+
+        verify(resendScheduledExecutorService).execute();
+    }
+
+    @Test
+    public void pauseResendScheduledExecutorService() {
+        underTest.pause("internal-broker");
+
+        verify(resendScheduledExecutorService).pause();
+    }
+
+    public static class StubRuntimeDelegate extends RuntimeDelegate {
+
+        @Override
+        public UriBuilder createUriBuilder() {
+            return null;
+        }
+
+        @Override
+        public Response.ResponseBuilder createResponseBuilder() {
+            Response.ResponseBuilder responseBuilder = mock(Response.ResponseBuilder.class);
+            when(responseBuilder.status((Response.StatusType)Response.Status.BAD_REQUEST)).thenReturn(responseBuilder);
+            Response response = mock(Response.class);
+            when(responseBuilder.build()).thenReturn(response);
+            when(response.getStatusInfo()).thenReturn(Response.Status.BAD_REQUEST);
+            return responseBuilder;
+        }
+
+        @Override
+        public Variant.VariantListBuilder createVariantListBuilder() {
+            return null;
+        }
+
+        @Override
+        public <T> T createEndpoint(Application application, Class<T> aClass) throws IllegalArgumentException, UnsupportedOperationException {
+            return null;
+        }
+
+        @Override
+        public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> aClass) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public Link.Builder createLinkBuilder() {
+            return null;
+        }
+    }
+
+
+}

--- a/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
+++ b/core/server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageProcessorConfiguration.java
@@ -1,0 +1,36 @@
+package uk.gov.dwp.queue.triage.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+import uk.gov.dwp.queue.triage.core.search.mongo.spring.MongoSearchConfiguration;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.core.service.processor.DisregardingFailedMessageProcessor;
+import uk.gov.dwp.queue.triage.core.service.processor.PredicateOutcomeFailedMessageProcessor;
+import uk.gov.dwp.queue.triage.core.service.processor.UniqueFailedMessageIdPredicate;
+import uk.gov.dwp.queue.triage.core.service.processor.UniqueJmsMessageIdPredicate;
+
+@Configuration
+@Import({
+        FailedMessageServiceConfiguration.class,
+        MongoSearchConfiguration.class
+})
+public class FailedMessageProcessorConfiguration {
+
+    @Bean
+    public PredicateOutcomeFailedMessageProcessor failedMessageProcessor(FailedMessageSearchService failedMessageSearchService,
+                                                                         FailedMessageService failedMessageService,
+                                                                         FailedMessageDao failedMessageDao) {
+        return new PredicateOutcomeFailedMessageProcessor(
+                new UniqueJmsMessageIdPredicate(failedMessageSearchService),
+                new PredicateOutcomeFailedMessageProcessor(
+                        new UniqueFailedMessageIdPredicate(failedMessageDao),
+                        failedMessageService::create,
+                        new DisregardingFailedMessageProcessor(failedMessage -> "is not unique, disregarding for now.")
+                ),
+                new DisregardingFailedMessageProcessor(failedMessage -> "with JMSMessageId=" + failedMessage.getJmsMessageId() + " is not unique")
+        );
+    }
+}

--- a/core/service/service.gradle
+++ b/core/service/service.gradle
@@ -1,19 +1,17 @@
 dependencies {
     implementation project(':common:id')
+    implementation project(':core:client')
     implementation project(':core:domain')
     implementation project(':core:dao')
+    implementation project(':core:search')
     implementation 'org.slf4j:slf4j-api'
 
     //test
+    testImplementation project(':core:client-test-support')
     testImplementation project(':core:domain-test-support')
-
-    // this was test:common
     testImplementation 'net.bytebuddy:byte-buddy'
+    testImplementation 'junit:junit'
     testImplementation 'org.hamcrest:hamcrest-core'
     testImplementation 'org.hamcrest:hamcrest-library'
-    testImplementation 'junit:junit'
     testImplementation 'org.mockito:mockito-core'
-    testImplementation 'net.bytebuddy:byte-buddy'
-    testImplementation 'org.objenesis:objenesis:2.5.1'
-    // this was test:common - end
 }

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/DisregardingFailedMessageProcessor.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/DisregardingFailedMessageProcessor.java
@@ -1,0 +1,22 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+import java.util.function.Function;
+
+public class DisregardingFailedMessageProcessor implements FailedMessageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DisregardingFailedMessageProcessor.class);
+
+    private final Function<FailedMessage, String> reason;
+
+    public DisregardingFailedMessageProcessor(Function<FailedMessage, String> reason) {
+        this.reason = reason;
+    }
+
+    public void process(FailedMessage failedMessage) {
+        LOGGER.debug("Disregarding FailedMessage: {} {}", failedMessage.getFailedMessageId(), reason.apply(failedMessage));
+    }
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/ExistingFailedMessageProcessor.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/ExistingFailedMessageProcessor.java
@@ -1,0 +1,18 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+public class ExistingFailedMessageProcessor implements FailedMessageProcessor {
+
+    private final FailedMessageDao failedMessageDao;
+
+    public ExistingFailedMessageProcessor(FailedMessageDao failedMessageDao) {
+        this.failedMessageDao = failedMessageDao;
+    }
+
+    @Override
+    public void process(FailedMessage failedMessage) {
+        failedMessageDao.update(failedMessage);
+    }
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/FailedMessageProcessor.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/FailedMessageProcessor.java
@@ -1,0 +1,8 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+public interface FailedMessageProcessor {
+
+    void process(FailedMessage failedMessage);
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/NewFailedMessageProcessor.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/NewFailedMessageProcessor.java
@@ -1,0 +1,18 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+
+public class NewFailedMessageProcessor implements FailedMessageProcessor {
+
+    private final FailedMessageService failedMessageService;
+
+    public NewFailedMessageProcessor(FailedMessageService failedMessageService) {
+        this.failedMessageService = failedMessageService;
+    }
+
+    @Override
+    public void process(FailedMessage failedMessage) {
+        failedMessageService.create(failedMessage);
+    }
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/PredicateOutcomeFailedMessageProcessor.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/PredicateOutcomeFailedMessageProcessor.java
@@ -1,0 +1,32 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+import java.util.function.Predicate;
+
+/**
+ * Based on if the FailedMessage is deemed unique, handles the message in one of two ways
+ */
+public class PredicateOutcomeFailedMessageProcessor implements FailedMessageProcessor {
+
+    private final Predicate<FailedMessage> predicate;
+    private final FailedMessageProcessor positiveOutcomeFailedMessageProcessor;
+    private final FailedMessageProcessor negativeOutcomeFailedMessageProcessor;
+
+    public PredicateOutcomeFailedMessageProcessor(Predicate<FailedMessage> predicate,
+                                                  FailedMessageProcessor positiveOutcomeFailedMessageProcessor,
+                                                  FailedMessageProcessor negativeOutcomeFailedMessageProcessor) {
+        this.predicate = predicate;
+        this.negativeOutcomeFailedMessageProcessor = negativeOutcomeFailedMessageProcessor;
+        this.positiveOutcomeFailedMessageProcessor = positiveOutcomeFailedMessageProcessor;
+    }
+
+    @Override
+    public void process(FailedMessage failedMessage) {
+        if (predicate.test(failedMessage)) {
+            positiveOutcomeFailedMessageProcessor.process(failedMessage);
+        } else {
+            negativeOutcomeFailedMessageProcessor.process(failedMessage);
+        }
+    }
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueFailedMessageIdPredicate.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueFailedMessageIdPredicate.java
@@ -1,0 +1,23 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+
+import java.util.function.Predicate;
+
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
+
+public class UniqueFailedMessageIdPredicate implements Predicate<FailedMessage> {
+
+    private final FailedMessageDao failedMessageDao;
+
+    public UniqueFailedMessageIdPredicate(FailedMessageDao failedMessageDao) {
+        this.failedMessageDao = failedMessageDao;
+    }
+
+    @Override
+    public boolean test(FailedMessage failedMessage) {
+        return failedMessageDao.findById(failedMessage.getFailedMessageId()) == null;
+    }
+}

--- a/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicate.java
+++ b/core/service/src/main/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicate.java
@@ -1,0 +1,26 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+
+import java.util.function.Predicate;
+
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest.searchMatchingAllCriteria;
+
+public class UniqueJmsMessageIdPredicate implements Predicate<FailedMessage> {
+
+    private final FailedMessageSearchService failedMessageSearchService;
+
+    public UniqueJmsMessageIdPredicate(FailedMessageSearchService failedMessageSearchService) {
+        this.failedMessageSearchService = failedMessageSearchService;
+    }
+
+    @Override
+    public boolean test(FailedMessage failedMessage) {
+        return failedMessageSearchService.search(searchMatchingAllCriteria()
+                .withBroker(failedMessage.getDestination().getBrokerName())
+                .withJmsMessageId(failedMessage.getJmsMessageId())
+                .build()
+        ).isEmpty();
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/ExistingFailedMessageProcessorTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/ExistingFailedMessageProcessorTest.java
@@ -1,0 +1,23 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ExistingFailedMessageProcessorTest {
+
+    private final FailedMessageDao failedMessageDao = mock(FailedMessageDao.class);
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+
+    private ExistingFailedMessageProcessor underTest = new ExistingFailedMessageProcessor(failedMessageDao);
+
+    @Test
+    public void successfullyProcessExistingFailedMessage() {
+        underTest.process(failedMessage);
+
+        verify(failedMessageDao).update(failedMessage);
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/NewFailedMessageProcessorTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/NewFailedMessageProcessorTest.java
@@ -1,0 +1,19 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+
+import static org.mockito.Mockito.mock;
+
+public class NewFailedMessageProcessorTest {
+
+    private final FailedMessageService failedMessageService = mock(FailedMessageService.class);
+    private final NewFailedMessageProcessor underTest = new NewFailedMessageProcessor(failedMessageService);
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+
+    @Test
+    public void delegatesToFailedMessageService() {
+        underTest.process(failedMessage);
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/PredicateOutcomeFailedMessageProcessorTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/PredicateOutcomeFailedMessageProcessorTest.java
@@ -1,0 +1,41 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class PredicateOutcomeFailedMessageProcessorTest {
+
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+    private boolean duplicate;
+    private final Predicate<FailedMessage> uniqueFailedMessagePredicate = failedMessage -> duplicate;
+    private final FailedMessageProcessor newFailedMessageProcessor = mock(FailedMessageProcessor.class);
+    private final FailedMessageProcessor duplicateFailedMessageProcessor = mock(FailedMessageProcessor.class);
+
+    private final PredicateOutcomeFailedMessageProcessor underTest = new PredicateOutcomeFailedMessageProcessor(uniqueFailedMessagePredicate, duplicateFailedMessageProcessor, newFailedMessageProcessor);
+
+    @Test
+    public void messageIsADuplicate() {
+        duplicate = true;
+
+        underTest.process(failedMessage);
+
+        verify(duplicateFailedMessageProcessor).process(failedMessage);
+        verifyZeroInteractions(newFailedMessageProcessor);
+    }
+
+    @Test
+    public void messageIsNotADuplicate() {
+        duplicate = false;
+
+        underTest.process(failedMessage);
+
+        verify(newFailedMessageProcessor).process(failedMessage);
+        verifyZeroInteractions(duplicateFailedMessageProcessor);
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueFailedMessageIdPredicateTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueFailedMessageIdPredicateTest.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
+
+public class UniqueFailedMessageIdPredicateTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = newFailedMessageId();
+
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+    private final FailedMessageDao failedMessageDao = mock(FailedMessageDao.class);
+
+    private final UniqueFailedMessageIdPredicate underTest = new UniqueFailedMessageIdPredicate(failedMessageDao);
+
+    @Test
+    public void predicateReturnsTrueWhenFailedMesageWithIdDoesNotExist() {
+        when(failedMessage.getFailedMessageId()).thenReturn(FAILED_MESSAGE_ID);
+        when(failedMessageDao.findById(FAILED_MESSAGE_ID)).thenReturn(null);
+
+        assertThat(underTest.test(failedMessage), is(true));
+    }
+
+    @Test
+    public void predicateReturnsFalseWhenFailedMessageWithIdExists() {
+        when(failedMessage.getFailedMessageId()).thenReturn(FAILED_MESSAGE_ID);
+        when(failedMessageDao.findById(FAILED_MESSAGE_ID)).thenReturn(failedMessage);
+
+        assertThat(underTest.test(failedMessage), is(false));
+    }
+}

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicateTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicateTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
 
 public class UniqueJmsMessageIdPredicateTest {
 

--- a/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicateTest.java
+++ b/core/service/src/test/java/uk/gov/dwp/queue/triage/core/service/processor/UniqueJmsMessageIdPredicateTest.java
@@ -1,0 +1,58 @@
+package uk.gov.dwp.queue.triage.core.service.processor;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.domain.Destination;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
+
+import java.util.Collections;
+
+import static java.util.Collections.singleton;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAllCriteria;
+
+public class UniqueJmsMessageIdPredicateTest {
+
+    private static final String JMS_MESSAGE_ID = "ID:localhost.localdomain-98564-1519823541516-5:1:1:1:1";
+    private static final String BROKER_NAME = "internal-broker";
+
+    private final FailedMessageSearchService failedMessageSearchService = mock(FailedMessageSearchService.class);
+    private final UniqueJmsMessageIdPredicate underTest = new UniqueJmsMessageIdPredicate(failedMessageSearchService);
+    private final Destination destination = mock(Destination.class);
+    private final FailedMessage failedMessage = mock(FailedMessage.class);
+
+    @Test
+    public void predicateReturnsTrueIfSearchFindsAResult() {
+        when(destination.getBrokerName()).thenReturn(BROKER_NAME);
+        when(failedMessage.getDestination()).thenReturn(destination);
+        when(failedMessage.getJmsMessageId()).thenReturn(JMS_MESSAGE_ID);
+        when(failedMessageSearchService.search(any(SearchFailedMessageRequest.class))).thenReturn(Collections.emptySet());
+
+        assertThat(underTest.test(failedMessage), is(true));
+
+        verify(failedMessageSearchService).search(argThat(aSearchRequestMatchingAllCriteria()
+                .withBroker(BROKER_NAME)
+                .withJmsMessageId(JMS_MESSAGE_ID)));
+    }
+
+    @Test
+    public void predicateReturnsFalseIfSearchFindsAResult() {
+        when(destination.getBrokerName()).thenReturn(BROKER_NAME);
+        when(failedMessage.getDestination()).thenReturn(destination);
+        when(failedMessage.getJmsMessageId()).thenReturn(JMS_MESSAGE_ID);
+        when(failedMessageSearchService.search(any(SearchFailedMessageRequest.class))).thenReturn(singleton(mock(FailedMessage.class)));
+
+        assertThat(underTest.test(failedMessage), is(false));
+
+        verify(failedMessageSearchService).search(argThat(aSearchRequestMatchingAllCriteria()
+                .withBroker(BROKER_NAME)
+                .withJmsMessageId(JMS_MESSAGE_ID)));
+    }
+}

--- a/dependency_config.gradle
+++ b/dependency_config.gradle
@@ -49,6 +49,7 @@ subprojects {
                 entry 'activemq-client'
                 entry 'activemq-broker'
                 entry 'activemq-kahadb-store'
+                entry 'activemq-pool'
             }
 
             dependencySet(group: 'org.apache.cxf', version: '3.1.11') {

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/ListFailedMessagesStage.java
@@ -7,7 +7,6 @@ import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.mockito.Mockito;
 import org.mockito.hamcrest.MockitoHamcrest;
-import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.openqa.selenium.By;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,9 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequest;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.SearchFailedMessageResponseBuilder;
-import uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jgiven.ReflectionArgumentFormatter;
 
@@ -28,8 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.codeborne.selenide.CollectionCondition.size;
-import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.Condition.visible;
 import static org.mockito.ArgumentMatchers.any;

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
@@ -10,8 +10,8 @@ import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.util.Optional;
 
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
 
 public class SearchFailedMessageComponentTest extends WebComponentTest<ListFailedMessagesStage, SearchFailedMessageWhenStage, FailedMessageListThenStage> {
 

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapterTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageRequestAdapterTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.dwp.queue.triage.core.domain.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
 
 public class SearchFailedMessageRequestAdapterTest {
 


### PR DESCRIPTION
- Introduced a new `FailedMessageProcessor` interface with a number of concrete implementations.  The default behavior is now:
  - A message with a duplicate JMS Message Id will be logged and disregarded 
  - A message with a duplicate Failed Message Id will be updated and re-processed again by the system.
- Added an endpoint (`/core/admin/jms-listener/read-messages/{brokerName}`) to allow on-demand execution of any read-only Queue Browser.
- Remove the createUsersAndRoles configuration from travis build (now executed prior to the test phase)