### PR TITLE
Added mavenCentral as the first repository to query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ scmVersion {
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
     }
     apply plugin: 'java'


### PR DESCRIPTION
jcenter is currently failing resolving random dependencies:
```
Download https://jcenter.bintray.com/org/springframework/spring-beans/4.3.8.RELEASE/spring-beans-4.3.8.RELEASE.jar
FAILURE: Build failed with an exception.
* What went wrong:
Could not resolve all files for configuration ':common:metrics:compileClasspath'.
> Could not find org.springframework.boot:spring-boot-autoconfigure:1.5.3.RELEASE.
  Required by:
      project :common:metrics
```