### PR TITLE
#120: Removed unnecessary Builder from the MessageClassifier

### DIFF
--- a/common/health/health.gradle
+++ b/common/health/health.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation 'javax.servlet:javax.servlet-api'
+    implementation 'org.slf4j:slf4j-api'
+
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'junit:junit'
 }

--- a/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
+++ b/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
@@ -1,5 +1,8 @@
 package uk.gov.dwp.queue.triage.health;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -8,7 +11,9 @@ import java.io.IOException;
 
 public class PingServlet extends HttpServlet {
 
-    private PingResponseWriter responseWriter;
+    private static Logger LOGGER = LoggerFactory.getLogger(PingServlet.class);
+
+    private final PingResponseWriter responseWriter;
 
     public PingServlet(PingResponseWriter responseWriter) {
         this.responseWriter = responseWriter;
@@ -16,6 +21,10 @@ public class PingServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        responseWriter.write(resp.getWriter());
+        try {
+            responseWriter.write(resp.getWriter());
+        } catch (IOException e) {
+            LOGGER.error("Unable to response writer", e);
+        }
     }
 }

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/JmsStage.java
@@ -47,9 +47,8 @@ public class JmsStage extends Stage<JmsStage> {
     }
 
     private void addMessageClassifierWithContent(String content, FailedMessageAction failedMessageAction) {
-        stubMessageClassifierResource.addMessageClassifier(MessageClassifier
-                .when(new ContentEqualToPredicate(content))
-                .then(failedMessageAction)
+        stubMessageClassifierResource.addMessageClassifier(new MessageClassifier(
+                new ContentEqualToPredicate(content), failedMessageAction)
         );
     }
 

--- a/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
+++ b/core/component-test/src/main/java/uk/gov/dwp/queue/triage/core/stub/app/configuration/StubAppJmsConfiguration.java
@@ -46,11 +46,7 @@ public class StubAppJmsConfiguration {
     }
 
     private MessageClassifier defaultMessageClassifier() {
-        return MessageClassifier
-                .when(failedMessage -> true)
-                .then(failedMessage -> {
-                    throw new RuntimeException("Head Shot!");
-                });
+        return new MessageClassifier(failedMessage -> true, failedMessage -> { throw new RuntimeException("Head Shot!"); });
     }
 
     @Bean(destroyMethod = "shutdown")

--- a/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/MessageClassifier.java
+++ b/core/message-classification/src/main/java/uk/gov/dwp/queue/triage/core/classification/MessageClassifier.java
@@ -5,57 +5,31 @@ import uk.gov.dwp.queue.triage.core.classification.action.FailedMessageAction;
 import uk.gov.dwp.queue.triage.core.classification.predicate.FailedMessagePredicate;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 public class MessageClassifier implements Predicate<FailedMessage>, Consumer<FailedMessage> {
 
     @JsonProperty
-    private final List<FailedMessagePredicate> predicates;
+    private final FailedMessagePredicate predicate;
     @JsonProperty
     private final FailedMessageAction action;
 
-    private MessageClassifier(@JsonProperty("predicates") List<FailedMessagePredicate> predicates,
-                              @JsonProperty("action") FailedMessageAction action) {
-        this.predicates = predicates;
+    public MessageClassifier(@JsonProperty("predicate") FailedMessagePredicate predicate,
+                             @JsonProperty("action") FailedMessageAction action) {
+        this.predicate = predicate;
         this.action = action;
     }
 
     @Override
     public boolean test(FailedMessage failedMessage) {
-        return predicates
-                .stream()
-                .allMatch(x -> x.test(failedMessage));
+        return predicate.test(failedMessage);
     }
 
     @Override
     public void accept(FailedMessage failedMessage) {
         if (test(failedMessage)) {
             action.accept(failedMessage);
-        }
-    }
-
-    public static MessageClassifierBuilder when(FailedMessagePredicate failedMessagePredicate) {
-        return new MessageClassifierBuilder(failedMessagePredicate);
-    }
-
-    public static class MessageClassifierBuilder {
-
-        private final List<FailedMessagePredicate> predicates = new ArrayList<>();
-
-        private MessageClassifierBuilder(FailedMessagePredicate failedMessagePredicate) {
-            this.predicates.add(failedMessagePredicate);
-        }
-
-        public MessageClassifierBuilder and(FailedMessagePredicate failedMessagePredicate) {
-            predicates.add(failedMessagePredicate);
-            return this;
-        }
-
-        public MessageClassifier then(FailedMessageAction action) {
-            return new MessageClassifier(predicates, action);
         }
     }
 }

--- a/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/MessageClassifierTest.java
+++ b/core/message-classification/src/test/java/uk/gov/dwp/queue/triage/core/classification/MessageClassifierTest.java
@@ -18,7 +18,7 @@ public class MessageClassifierTest {
 
     @Test
     public void actionIsExecutedIfThePredicateIsTrue() {
-        MessageClassifier underTest = MessageClassifier.when(alwaysTrue).then(failedMessageAction);
+        MessageClassifier underTest = new MessageClassifier(alwaysTrue, failedMessageAction);
 
         underTest.accept(failedMessage);
 
@@ -27,11 +27,10 @@ public class MessageClassifierTest {
 
     @Test
     public void actionIsNotExecutedIfThePredicateIsFalse() {
-        MessageClassifier underTest = MessageClassifier.when(alwaysFalse).then(failedMessageAction);
+        MessageClassifier underTest = new MessageClassifier(alwaysFalse, failedMessageAction);
 
         underTest.accept(failedMessage);
 
         verifyZeroInteractions(failedMessageAction);
     }
-
 }


### PR DESCRIPTION
With the creation of the `AndPredicate` and `OrPredicate` classes in commit 80de05d the MessageClassifier builder is no longer required / makes sense