### PR TITLE
#151 - More test coverage

### DIFF
--- a/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
+++ b/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
@@ -3,7 +3,6 @@ package uk.gov.dwp.queue.triage.health;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -22,12 +21,20 @@ public class PingServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
         try {
             responseWriter.write(resp.getWriter());
         } catch (IOException e) {
+            handleError(resp, e);
+        }
+    }
+
+    private void handleError(HttpServletResponse resp, IOException e) {
+        try {
             LOGGER.error("Unable to get response writer", e);
             resp.sendError(SC_INTERNAL_SERVER_ERROR, "An error occurred writing the response");
+        } catch (IOException ignore) {
+            // No op
         }
     }
 }

--- a/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
+++ b/common/health/src/main/java/uk/gov/dwp/queue/triage/health/PingServlet.java
@@ -12,7 +12,7 @@ import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 
 public class PingServlet extends HttpServlet {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(PingServlet.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PingServlet.class);
 
     private final PingResponseWriter responseWriter;
 

--- a/common/id/id.gradle
+++ b/common/id/id.gradle
@@ -1,3 +1,5 @@
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
+
+    testImplementation 'junit:junit'
 }

--- a/common/id/src/test/java/uk/gov/dwp/queue/triage/id/FailedMessageIdTest.java
+++ b/common/id/src/test/java/uk/gov/dwp/queue/triage/id/FailedMessageIdTest.java
@@ -1,0 +1,46 @@
+package uk.gov.dwp.queue.triage.id;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FailedMessageIdTest {
+
+    private static final UUID A_UUID = UUID.randomUUID();
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+
+    @Test
+    public void generateFailedMessageIdFromUUID() {
+        assertEquals(A_UUID, FailedMessageId.fromUUID(A_UUID).getId());
+    }
+
+    @Test
+    public void generateFailedMesasgeIdFromString() {
+        assertEquals(A_UUID, FailedMessageId.fromString(A_UUID.toString()).getId());
+    }
+
+    @Test
+    public void equalsTest() {
+        assertFalse(FAILED_MESSAGE_ID.equals(null));
+        assertFalse(FailedMessageId.fromUUID(A_UUID).equals(A_UUID));
+        assertFalse(FailedMessageId.newFailedMessageId().equals(FAILED_MESSAGE_ID));
+        assertTrue(FAILED_MESSAGE_ID.equals(FAILED_MESSAGE_ID));
+        assertTrue(FailedMessageId.fromUUID(A_UUID).equals(FailedMessageId.fromUUID(A_UUID)));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        assertNotEquals(FAILED_MESSAGE_ID.hashCode(), FailedMessageId.newFailedMessageId().hashCode());
+        assertEquals(FAILED_MESSAGE_ID.getId().hashCode(), FAILED_MESSAGE_ID.hashCode());
+    }
+
+    @Test
+    public void toStringTest() {
+        assertEquals(FAILED_MESSAGE_ID.getId().toString(), FAILED_MESSAGE_ID.toString());
+    }
+}

--- a/core/client/client.gradle
+++ b/core/client/client.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'io.swagger:swagger-annotations'
 
     testImplementation project(':core:client-test-support')
+    testImplementation project(':common:jackson')
     testImplementation 'junit:junit'
     testImplementation "org.hamcrest:hamcrest-library"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequest.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class CreateFailedMessageRequest {
@@ -132,7 +133,7 @@ public class CreateFailedMessageRequest {
         }
 
         public CreateFailedMessageRequestBuilder withProperties(Map<String, Object> properties) {
-            this.properties = (properties != null) ? properties : new HashMap<>();
+            this.properties = Optional.ofNullable(properties).map(HashMap::new).orElse(new HashMap<>());
             return this;
         }
 
@@ -142,7 +143,7 @@ public class CreateFailedMessageRequest {
         }
 
         public CreateFailedMessageRequestBuilder withLabels(Set<String> labels) {
-            this.labels = (labels != null) ? labels : new HashSet<>();
+            this.labels = Optional.ofNullable(labels).map(HashSet::new).orElse(new HashSet<>());
             return this;
         }
 

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
@@ -5,6 +5,7 @@ import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -15,7 +16,7 @@ public class SearchFailedMessageResponse {
     private final String jmsMessageId;
     @NotNull
     private final String broker;
-    private final Optional<String> destination;
+    private final String destination;
     @NotNull
     private final Instant sentDateTime;
     @NotNull
@@ -30,7 +31,7 @@ public class SearchFailedMessageResponse {
     private SearchFailedMessageResponse(@JsonProperty("failedMessageId") FailedMessageId failedMessageId,
                                         @JsonProperty("jmsMessageId") String jmsMessageId,
                                         @JsonProperty("broker") String broker,
-                                        @JsonProperty("destination") Optional<String> destination,
+                                        @JsonProperty("destination") String destination,
                                         @JsonProperty("sentDateTime") Instant sentDateTime,
                                         @JsonProperty("failedDateTime") Instant lastFailedDateTime,
                                         @JsonProperty("content") String content,
@@ -58,7 +59,7 @@ public class SearchFailedMessageResponse {
     }
 
     public Optional<String> getDestination() {
-        return destination;
+        return Optional.ofNullable(destination);
     }
 
     public Instant getSentDateTime() {
@@ -96,11 +97,11 @@ public class SearchFailedMessageResponse {
         private FailedMessageId failedMessageId;
         private String jmsMessageId;
         private String broker;
-        private Optional<String> destination = Optional.empty();
+        private String destination;
         private Instant sentDateTime;
         private Instant failedDateTime;
         private String content;
-        private Set<String> labels;
+        private Set<String> labels = new HashSet<>();
 
         private SearchFailedMessageResponseBuilder() {
         }
@@ -120,7 +121,7 @@ public class SearchFailedMessageResponse {
             return this;
         }
 
-        public SearchFailedMessageResponseBuilder withDestination(Optional<String> destination) {
+        public SearchFailedMessageResponseBuilder withDestination(String destination) {
             this.destination = destination;
             return this;
         }

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequestTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/CreateFailedMessageRequestTest.java
@@ -1,0 +1,167 @@
+package uk.gov.dwp.queue.triage.core.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.collection.IsEmptyIterable;
+import org.hamcrest.core.IsAnything;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.CreateFailedMessageRequestBuilder;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.dwp.queue.triage.core.client.CreateFailedMessageRequest.newCreateFailedMessageRequest;
+
+public class CreateFailedMessageRequestTest {
+
+    private static final Instant NOW = Instant.now();
+    private static final String BROKER_NAME = "some-broker";
+    private static final String DESTINATION_NAME = "some-destination";
+    private static final String MESSAGE_CONTENT = "content";
+
+    private final CreateFailedMessageRequestBuilder createFailedMessageRequestBuilder = newCreateFailedMessageRequest()
+            .withContent(MESSAGE_CONTENT)
+            .withBrokerName(BROKER_NAME)
+            .withDestinationName(DESTINATION_NAME)
+            .withFailedDateTime(NOW)
+            .withSentDateTime(NOW);
+
+    @Test
+    public void attemptingToSetNullPropertiesCreatesAnEmptyMap() {
+        final CreateFailedMessageRequest createFailedMessageRequest = createFailedMessageRequestBuilder
+                .withProperties(null)
+                .build();
+
+        assertThat(createFailedMessageRequest, is(createFailedMessageRequest().withProperties(equalTo(emptyMap()))));
+    }
+
+    @Test
+    public void attemptingToSetNullLabelsCreatesAnEmptySet() {
+        final CreateFailedMessageRequest createFailedMessageRequest = createFailedMessageRequestBuilder
+                .withLabels(null)
+                .build();
+
+        assertThat(createFailedMessageRequest, is(createFailedMessageRequest().withLabels(emptyIterable())));
+    }
+
+    @Test
+    public void addProperties() {
+        final CreateFailedMessageRequest createFailedMessageRequest = createFailedMessageRequestBuilder
+                .withProperties(Collections.singletonMap("foo", "bar"))
+                .withProperty("ham", "eggs")
+                .build();
+
+        assertThat(createFailedMessageRequest, is(createFailedMessageRequest()
+                .withProperties(allOf(Matchers.hasEntry("foo", "bar"), Matchers.hasEntry("ham", "eggs")))));
+    }
+
+    @Test
+    public void addLabels() {
+        final CreateFailedMessageRequest createFailedMessageRequest = createFailedMessageRequestBuilder
+                .withLabels(Collections.singleton("foo"))
+                .withLabel("bar")
+                .build();
+
+        assertThat(createFailedMessageRequest, is(createFailedMessageRequest()
+                .withLabels(containsInAnyOrder("foo", "bar"))));
+    }
+
+    public static CreateFailedMessageRequestMatcher createFailedMessageRequest() {
+        return new CreateFailedMessageRequestMatcher()
+                .withBrokerName(equalTo(BROKER_NAME))
+                .withDestinationName(equalTo(DESTINATION_NAME))
+                .withContent(equalTo(MESSAGE_CONTENT))
+                .withFailedAt(equalTo(NOW))
+                .withSentAt(equalTo(NOW));
+    }
+
+    private static class CreateFailedMessageRequestMatcher extends TypeSafeMatcher<CreateFailedMessageRequest> {
+        private Matcher<FailedMessageId> failedMessageIdMatcher = new IsAnything<>();
+        private Matcher<String> contentMatcher = new IsAnything<>();
+        private Matcher<String> brokerNameMatcher = new IsAnything<>();
+        private Matcher<String> destinationNameMatcher = new IsAnything<>();
+        private Matcher<Instant> sentAtMatcher = new IsAnything<>();
+        private Matcher<Instant> failedAtMatcher = new IsAnything<>();
+        private Matcher<Map<? extends String, ? extends Object>> propertiesMatcher = equalTo(new HashMap<>());
+        private Matcher<Iterable<? extends String>> labelsMatcher = new IsEmptyIterable<>();
+
+        @Override
+        protected boolean matchesSafely(CreateFailedMessageRequest item) {
+            return failedMessageIdMatcher.matches(item.getFailedMessageId())
+                    && contentMatcher.matches(item.getContent())
+                    && brokerNameMatcher.matches(item.getBrokerName())
+                    && destinationNameMatcher.matches(item.getDestinationName())
+                    && sentAtMatcher.matches(item.getSentAt())
+                    && failedAtMatcher.matches(item.getFailedAt())
+                    && propertiesMatcher.matches(item.getProperties())
+                    && labelsMatcher.matches(item.getLabels())
+                    ;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description
+                    .appendText("failedMessageId is ").appendDescriptionOf(failedMessageIdMatcher)
+                    .appendText(" content is ").appendDescriptionOf(contentMatcher)
+                    .appendText(" broker is ").appendDescriptionOf(brokerNameMatcher)
+                    .appendText(" destination is ").appendDescriptionOf(destinationNameMatcher)
+                    .appendText(" sentAt is ").appendDescriptionOf(sentAtMatcher)
+                    .appendText(" failedAt is ").appendDescriptionOf(failedAtMatcher)
+                    .appendText(" properties are ").appendDescriptionOf(propertiesMatcher)
+                    .appendText(" labels are ").appendDescriptionOf(labelsMatcher)
+            ;
+        }
+
+        public CreateFailedMessageRequestMatcher withFailedMessageId(Matcher<FailedMessageId> failedMessageIdMatcher) {
+            this.failedMessageIdMatcher = failedMessageIdMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withContent(Matcher<String> contentMatcher) {
+            this.contentMatcher = contentMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withBrokerName(Matcher<String> brokerNameMatcher) {
+            this.brokerNameMatcher = brokerNameMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withDestinationName(Matcher<String> destinationNameMatcher) {
+            this.destinationNameMatcher = destinationNameMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withSentAt(Matcher<Instant> sentAtMatcher) {
+            this.sentAtMatcher = sentAtMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withFailedAt(Matcher<Instant> failedAtMatcher) {
+            this.failedAtMatcher = failedAtMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withProperties(Matcher<Map<? extends String, ? extends Object>> propertiesMatcher) {
+            this.propertiesMatcher = propertiesMatcher;
+            return this;
+        }
+
+        public CreateFailedMessageRequestMatcher withLabels(Matcher<Iterable<? extends String>> labelsMatcher) {
+            this.labelsMatcher = labelsMatcher;
+            return this;
+        }
+    }
+}

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseTest.java
@@ -1,0 +1,78 @@
+package uk.gov.dwp.queue.triage.core.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.SearchFailedMessageResponseBuilder;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
+
+public class SearchFailedMessageResponseTest {
+
+    private static final Instant NOW = Instant.now();
+    private static final String BROKER_NAME = "broker-name";
+    private static final String DESTINATION_NAME = "destination-name";
+    private static final String SOME_CONTENT = "some-content";
+    private static final String JMS_MESSAGE_ID = "jms-message-id";
+    private static final FailedMessageId FAILED_MESSAGE_ID = newFailedMessageId();
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
+
+    private final SearchFailedMessageResponseBuilder searchFailedMessageResponseBuilder = newSearchFailedMessageResponse()
+            .withBroker(BROKER_NAME)
+            .withContent(SOME_CONTENT)
+            .withFailedMessageId(FAILED_MESSAGE_ID)
+            .withFailedDateTime(NOW.plusSeconds(1))
+            .withJmsMessageId(JMS_MESSAGE_ID)
+            .withSentDateTime(NOW);
+
+    @Test
+    public void serialiseAndDeserialiseObjectWithDefaults() throws IOException {
+        final String json = OBJECT_MAPPER.writeValueAsString(searchFailedMessageResponseBuilder
+                .build());
+
+        assertThat(OBJECT_MAPPER.readValue(json, SearchFailedMessageResponse.class), is(aFailedMessage()
+                .withBroker(equalTo(BROKER_NAME))
+                .withContent(equalTo(SOME_CONTENT))
+                .withDestination(equalTo(Optional.empty()))
+                .withFailedDateTime(NOW.plusSeconds(1))
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withSentDateTime(NOW)
+                .withLabels(emptyIterable())
+        ));
+    }
+
+    @Test
+    public void serialiseAndDeserialiseObject() throws IOException {
+        final String json = OBJECT_MAPPER.writeValueAsString(searchFailedMessageResponseBuilder
+                .withDestination(DESTINATION_NAME)
+                .withLabels(Collections.singleton("foo"))
+                .build());
+
+        assertThat(OBJECT_MAPPER.readValue(json, SearchFailedMessageResponse.class), is(aFailedMessage()
+                .withBroker(equalTo(BROKER_NAME))
+                .withContent(equalTo(SOME_CONTENT))
+                .withDestination(equalTo(Optional.of(DESTINATION_NAME)))
+                .withFailedDateTime(NOW.plusSeconds(1))
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withSentDateTime(NOW)
+                .withLabels(contains("foo"))
+        ));
+    }
+
+
+}

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponseTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponseTest.java
@@ -1,0 +1,33 @@
+package uk.gov.dwp.queue.triage.core.client.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.FAILED;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryResponseMatcher.statusHistoryResponse;
+
+public class StatusHistoryResponseTest {
+
+    private static final Instant NOW = Instant.now();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module());
+
+    private final StatusHistoryResponse underTest = new StatusHistoryResponse(FAILED, NOW);
+
+    @Test
+    public void statusHistoryResponseTest() {
+        assertThat(underTest, is(statusHistoryResponse().withStatus(FAILED).withEffectiveDateTime(NOW)));
+    }
+
+    @Test
+    public void serialiseAndDeserialiseObject() throws IOException {
+        final String json = OBJECT_MAPPER.writeValueAsString(underTest);
+        assertThat(OBJECT_MAPPER.readValue(json, StatusHistoryResponse.class), is(statusHistoryResponse().withStatus(FAILED).withEffectiveDateTime(NOW)));
+    }
+}

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponseTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/status/StatusHistoryResponseTest.java
@@ -1,8 +1,8 @@
 package uk.gov.dwp.queue.triage.core.client.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -15,8 +15,7 @@ import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryResponseMatcher.s
 public class StatusHistoryResponseTest {
 
     private static final Instant NOW = Instant.now();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module());
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
 
     private final StatusHistoryResponse underTest = new StatusHistoryResponse(FAILED, NOW);
 

--- a/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
+++ b/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/configuration/FailedMessageResourceConfiguration.java
@@ -3,22 +3,21 @@ package uk.gov.dwp.queue.triage.core.configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import uk.gov.dwp.queue.triage.core.resource.status.FailedMessageStatusHistoryResource;
-import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
-import uk.gov.dwp.queue.triage.cxf.ResourceRegistry;
 import uk.gov.dwp.queue.triage.core.dao.FailedMessageDao;
 import uk.gov.dwp.queue.triage.core.dao.mongo.configuration.MongoDaoConfig;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter;
 import uk.gov.dwp.queue.triage.core.resource.create.CreateFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.create.FailedMessageFactory;
 import uk.gov.dwp.queue.triage.core.resource.label.LabelFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.resend.ResendFailedMessageResource;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageResponseFactory;
 import uk.gov.dwp.queue.triage.core.resource.search.FailedMessageSearchResource;
+import uk.gov.dwp.queue.triage.core.resource.status.FailedMessageStatusHistoryResource;
 import uk.gov.dwp.queue.triage.core.search.FailedMessageSearchService;
 import uk.gov.dwp.queue.triage.core.search.SearchFailedMessageResponseAdapter;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageLabelService;
 import uk.gov.dwp.queue.triage.core.service.FailedMessageService;
+import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
+import uk.gov.dwp.queue.triage.cxf.ResourceRegistry;
 
 import java.time.Clock;
 
@@ -41,7 +40,7 @@ public class FailedMessageResourceConfiguration {
                                                                    FailedMessageSearchService failedMessageSearchService) {
         return resourceRegistry.add(new FailedMessageSearchResource(
                 failedMessageDao,
-                new FailedMessageResponseFactory(new FailedMessageStatusAdapter()),
+                new FailedMessageResponseFactory(),
                 failedMessageSearchService,
                 new SearchFailedMessageResponseAdapter()
         ));

--- a/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
+++ b/core/core-server/src/main/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactory.java
@@ -6,12 +6,6 @@ import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter;
 
 public class FailedMessageResponseFactory {
 
-    private final FailedMessageStatusAdapter failedMessageStatusAdapter;
-
-    public FailedMessageResponseFactory(FailedMessageStatusAdapter failedMessageStatusAdapter) {
-        this.failedMessageStatusAdapter = failedMessageStatusAdapter;
-    }
-
     public FailedMessageResponse create(FailedMessage failedMessage) {
         return new FailedMessageResponse(
                 failedMessage.getFailedMessageId(),
@@ -20,7 +14,7 @@ public class FailedMessageResponseFactory {
                 failedMessage.getSentAt(),
                 failedMessage.getFailedAt(),
                 failedMessage.getContent(),
-                failedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getStatusHistoryEvent().getStatus()),
+                FailedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getStatusHistoryEvent().getStatus()),
                 failedMessage.getProperties(),
                 failedMessage.getLabels());
     }

--- a/core/core-server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactoryTest.java
+++ b/core/core-server/src/test/java/uk/gov/dwp/queue/triage/core/resource/search/FailedMessageResponseFactoryTest.java
@@ -4,7 +4,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.core.client.FailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
-import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -22,7 +21,7 @@ public class FailedMessageResponseFactoryTest {
     private static final Instant NOW = Instant.now();
     private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
 
-    private final FailedMessageResponseFactory underTest = new FailedMessageResponseFactory(new FailedMessageStatusAdapter());
+    private final FailedMessageResponseFactory underTest = new FailedMessageResponseFactory();
 
     @Test
     public void createFailedMessageResponseFromAFailedMessage() {

--- a/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
+++ b/core/domain/src/main/java/uk/gov/dwp/queue/triage/core/domain/FailedMessageStatusAdapter.java
@@ -7,7 +7,6 @@ import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -16,7 +15,7 @@ public final class FailedMessageStatusAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageStatusAdapter.class);
 
-    private static Map<Status, FailedMessageStatus> statusToFailedMessageStatus = new HashMap<>();
+    private static Map<Status, FailedMessageStatus> statusToFailedMessageStatus = new EnumMap<>(Status.class);
     private static Map<FailedMessageStatus, Set<Status>> failedMessageStatusToStatusMapping = new EnumMap<>(FailedMessageStatus.class);
 
     static {
@@ -30,6 +29,9 @@ public final class FailedMessageStatusAdapter {
         failedMessageStatusToStatusMapping.put(FailedMessageStatus.SENT, Sets.immutableEnumSet(Status.SENT));
     }
 
+    private FailedMessageStatusAdapter() {
+        // No-op
+    }
 
     public static FailedMessageStatus toFailedMessageStatus(Status status) {
         FailedMessageStatus failedMessageStatus = statusToFailedMessageStatus.get(status);

--- a/core/search/search.gradle
+++ b/core/search/search.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot'
 
     testImplementation project(':core:dao-mongo-test-support')
+    testImplementation project(':core:client-test-support')
     testImplementation 'junit:junit'
     testImplementation 'org.hamcrest:hamcrest-core'
     testImplementation 'org.hamcrest:hamcrest-library'

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
@@ -11,7 +11,7 @@ public class SearchFailedMessageResponseAdapter {
         return newSearchFailedMessageResponse()
                 .withBroker(failedMessage.getDestination().getBrokerName())
                 .withContent(failedMessage.getContent())
-                .withDestination(failedMessage.getDestination().getName())
+                .withDestination(failedMessage.getDestination().getName().orElse(null))
                 .withFailedDateTime(failedMessage.getFailedAt())
                 .withFailedMessageId(failedMessage.getFailedMessageId())
                 .withJmsMessageId(failedMessage.getJmsMessageId())

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapter.java
@@ -20,7 +20,7 @@ public class MongoSearchResponseAdapter {
         return newSearchFailedMessageResponse()
                 .withFailedMessageId(failedMessageConverter.getFailedMessageId(basicDBObject))
                 .withBroker(destination.getBrokerName())
-                .withDestination(destination.getName())
+                .withDestination(destination.getName().orElse(null))
                 .withContent(failedMessageConverter.getContent(basicDBObject))
                 .withSentDateTime(failedMessageConverter.getSentDateTime(basicDBObject))
                 .withFailedDateTime(failedMessageConverter.getFailedDateTime(basicDBObject))

--- a/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapterTest.java
+++ b/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapterTest.java
@@ -1,0 +1,69 @@
+package uk.gov.dwp.queue.triage.core.search;
+
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.domain.Destination;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponseMatcher.aFailedMessage;
+import static uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent.Status.FAILED;
+import static uk.gov.dwp.queue.triage.id.FailedMessageId.newFailedMessageId;
+
+public class SearchFailedMessageResponseAdapterTest {
+
+    private static final Instant NOW = Instant.now();
+    private static final String BROKER_NAME = "broker-name";
+    private static final String DESTINATION_NAME = "destination-name";
+    private static final String SOME_CONTENT = "some-content";
+    private static final String JMS_MESSAGE_ID = "jms-message-id";
+    private static final FailedMessageId FAILED_MESSAGE_ID = newFailedMessageId();
+
+    private final FailedMessageBuilder failedMessageBuilder = FailedMessageBuilder.newFailedMessage()
+            .withContent(SOME_CONTENT)
+            .withFailedMessageId(FAILED_MESSAGE_ID)
+            .withFailedDateTime(NOW.plusSeconds(1))
+            .withJmsMessageId(JMS_MESSAGE_ID)
+            .withSentDateTime(NOW)
+            .withProperties(Collections.singletonMap("foo", "bar"))
+            .withLabel("foo")
+            .withStatusHistoryEvent(new StatusHistoryEvent(FAILED, NOW));
+
+    private final SearchFailedMessageResponseAdapter underTest = new SearchFailedMessageResponseAdapter();
+
+    @Test
+    public void destinationNameIsEmpty() {
+        assertThat(underTest.toResponse(failedMessageBuilder.withDestination(new Destination(BROKER_NAME, Optional.empty())).build()), is(aFailedMessage()
+                .withBroker(equalTo(BROKER_NAME))
+                .withContent(equalTo(SOME_CONTENT))
+                .withDestination(equalTo(Optional.empty()))
+                .withFailedDateTime(NOW.plusSeconds(1))
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withSentDateTime(NOW)
+                .withLabels(contains("foo"))
+        ));
+    }
+
+    @Test
+    public void destinationNameIsPopulated() {
+        assertThat(underTest.toResponse(failedMessageBuilder.withDestination(new Destination(BROKER_NAME, Optional.of(DESTINATION_NAME))).build()), is(aFailedMessage()
+                .withBroker(equalTo(BROKER_NAME))
+                .withContent(equalTo(SOME_CONTENT))
+                .withDestination(equalTo(Optional.of(DESTINATION_NAME)))
+                .withFailedDateTime(NOW.plusSeconds(1))
+                .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
+                .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
+                .withSentDateTime(NOW)
+                .withLabels(contains("foo"))
+        ));
+    }
+}

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/delete/DeleteFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/delete/DeleteFailedMessageComponentTest.java
@@ -8,7 +8,6 @@ import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -28,7 +27,7 @@ public class DeleteFailedMessageComponentTest extends WebComponentTest<ListFaile
         given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")
@@ -36,7 +35,7 @@ public class DeleteFailedMessageComponentTest extends WebComponentTest<ListFaile
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
-                .withDestination(Optional.of("topic-name"))
+                .withDestination("topic-name")
                 .withSentDateTime(NOW.minus(1, HOURS))
                 .withFailedDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
@@ -9,7 +9,6 @@ import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -34,7 +33,7 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
         listFailedMessagesStage.given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")
@@ -42,7 +41,7 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
         listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
-                .withDestination(Optional.of("topic-name"))
+                .withDestination("topic-name")
                 .withSentDateTime(NOW.minus(1, HOURS))
                 .withFailedDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
@@ -60,11 +59,11 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
     }
 
     @Test
-    public void removeLabelsFromAFailedMessage() throws Exception {
+    public void removeLabelsFromAFailedMessage() {
         listFailedMessagesStage.given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")
@@ -72,7 +71,7 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
         listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
-                .withDestination(Optional.of("topic-name"))
+                .withDestination("topic-name")
                 .withSentDateTime(NOW.minus(1, HOURS))
                 .withFailedDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
@@ -3,12 +3,10 @@ package uk.gov.dwp.queue.triage.web.component.list;
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
-import uk.gov.dwp.queue.triage.web.component.SimpleBaseWebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -27,7 +25,7 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
         given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")
@@ -35,7 +33,7 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
-                .withDestination(Optional.of("topic-name"))
+                .withDestination("topic-name")
                 .withSentDateTime(NOW.minus(1, HOURS))
                 .withFailedDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
@@ -60,7 +58,7 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
         given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/resend/ResendFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/resend/ResendFailedMessageComponentTest.java
@@ -8,7 +8,6 @@ import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -24,11 +23,11 @@ public class ResendFailedMessageComponentTest extends WebComponentTest<ListFaile
     private LoginGivenStage loginGivenStage;
 
     @Test
-    public void resendFailedMessageTest() throws Exception {
+    public void resendFailedMessageTest() {
         given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(NOW.minus(1, MINUTES))
                 .withFailedDateTime(NOW)
                 .withContent("Boom")
@@ -36,7 +35,7 @@ public class ResendFailedMessageComponentTest extends WebComponentTest<ListFaile
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
-                .withDestination(Optional.of("topic-name"))
+                .withDestination("topic-name")
                 .withSentDateTime(NOW.minus(1, HOURS))
                 .withFailedDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
@@ -8,8 +8,6 @@ import uk.gov.dwp.queue.triage.web.component.list.FailedMessageListThenStage;
 import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
-import java.util.Optional;
-
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -32,7 +30,7 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
                 newSearchFailedMessageResponse()
                         .withFailedMessageId(FAILED_MESSAGE_ID_1)
                         .withBroker("main-broker")
-                        .withDestination(Optional.of("queue-name"))
+                        .withDestination("queue-name")
                         .withContent("This message contains some-text")
                         .build()
         );
@@ -51,7 +49,7 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
                 newSearchFailedMessageResponse()
                         .withFailedMessageId(FAILED_MESSAGE_ID_1)
                         .withBroker("main-broker")
-                        .withDestination(Optional.of("queue-name"))
+                        .withDestination("queue-name")
                         .withContent("This message contains some-text")
                         .build()
         );

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
@@ -32,8 +32,7 @@ public class FailedMessageListItemAdapter {
                         toString(fm.getLastFailedDateTime()),
                         Optional.ofNullable(fm.getLabels())
                                 .filter(IS_EMPTY.negate())
-                                .map(Collection::stream)
-                                .map(x -> x.collect(Collectors.joining(", ")))
+                                .map(x -> String.join(", ", x))
                                 .orElse(null)))
                 .collect(Collectors.toList());
     }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.time.ZoneOffset.UTC;
@@ -16,6 +18,7 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 public class FailedMessageListItemAdapter {
 
     private static final DateTimeFormatter ISO_DATE_TIME_WITH_MS = ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC);
+    private static final Predicate<Set<String>> IS_EMPTY = Set::isEmpty;
 
     public List<FailedMessageListItem> adapt(Collection<SearchFailedMessageResponse> failedMessages) {
         return failedMessages
@@ -28,7 +31,9 @@ public class FailedMessageListItemAdapter {
                         toString(fm.getSentDateTime()),
                         toString(fm.getLastFailedDateTime()),
                         Optional.ofNullable(fm.getLabels())
-                                .map(labels -> labels.stream().collect(Collectors.joining(", ")))
+                                .filter(IS_EMPTY.negate())
+                                .map(Collection::stream)
+                                .map(x -> x.collect(Collectors.joining(", ")))
                                 .orElse(null)))
                 .collect(Collectors.toList());
     }

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
@@ -14,7 +14,6 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.ZoneOffset.UTC;
@@ -39,7 +38,7 @@ public class FailedMessageListItemAdapterTest {
         SearchFailedMessageResponse failedMessage1 = SearchFailedMessageResponse.newSearchFailedMessageResponse()
                 .withFailedMessageId(FailedMessageId.fromString(FAILED_MESSAGE_ID_1))
                 .withBroker("internal-broker")
-                .withDestination(Optional.of("queue-name"))
+                .withDestination("queue-name")
                 .withSentDateTime(EPOCH)
                 .withFailedDateTime(SOME_DATE_TIME)
                 .withContent("Some Content")
@@ -47,7 +46,7 @@ public class FailedMessageListItemAdapterTest {
         SearchFailedMessageResponse failedMessage2 = SearchFailedMessageResponse.newSearchFailedMessageResponse()
                 .withFailedMessageId(FailedMessageId.fromString(FAILED_MESSAGE_ID_2))
                 .withBroker("internal-broker")
-                .withDestination(Optional.of("another-queue"))
+                .withDestination("another-queue")
                 .withSentDateTime(SOME_DATE_TIME)
                 .withFailedDateTime(SOME_DATE_TIME.with(MILLI_OF_SECOND, 123))
                 .withContent("More Content")


### PR DESCRIPTION
- Improved the test coverage further on some of the domain / client objects
- Stopped using `Optional<String>` as a type parameter for the `destination` field in the `SearchFailedMessageResponse` constructor / builder.