### PR TITLE
#128: Rename JmsMessageDataProvider to JmsMessageTransformer

### DIFF
--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageTransformer.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageTransformer.java
@@ -9,11 +9,11 @@ import javax.jms.JMSException;
 import javax.jms.TextMessage;
 import java.util.Map;
 
-public class FailedMessageDataProvider implements JmsMessageDataProvider<TextMessage, FailedMessage> {
+public class FailedMessageTransformer implements JmsMessageTransformer<TextMessage, FailedMessage> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageDataProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailedMessageTransformer.class);
     @Override
-    public void provide(TextMessage textMessage, FailedMessage data) throws JMSException {
+    public void transform(TextMessage textMessage, FailedMessage data) throws JMSException {
         textMessage.setText(data.getContent());
         Map<String, Object> properties = data.getProperties();
         properties.keySet().forEach(key -> {

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageDataProvider.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageDataProvider.java
@@ -1,8 +1,0 @@
-package uk.gov.dwp.queue.triage.core.jms;
-
-import javax.jms.JMSException;
-import javax.jms.Message;
-
-public interface JmsMessageDataProvider<M extends Message, T> {
-    void provide(M jmsMessage, T data) throws JMSException;
-}

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageTransformer.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/JmsMessageTransformer.java
@@ -1,0 +1,8 @@
+package uk.gov.dwp.queue.triage.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+public interface JmsMessageTransformer<M extends Message, T> {
+    void transform(M jmsMessage, T data) throws JMSException;
+}

--- a/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreator.java
+++ b/core/jms/src/main/java/uk/gov/dwp/queue/triage/core/jms/spring/FailedMessageCreator.java
@@ -2,7 +2,8 @@ package uk.gov.dwp.queue.triage.core.jms.spring;
 
 import org.springframework.jms.core.MessageCreator;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
-import uk.gov.dwp.queue.triage.core.jms.FailedMessageDataProvider;
+import uk.gov.dwp.queue.triage.core.jms.FailedMessageTransformer;
+import uk.gov.dwp.queue.triage.core.jms.JmsMessageTransformer;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -14,18 +15,23 @@ import java.util.List;
 public class FailedMessageCreator implements MessageCreator {
 
     private final FailedMessage failedMessage;
-    private final List<FailedMessageDataProvider> failedMessageDataProviders;
+    private final List<JmsMessageTransformer<TextMessage, FailedMessage>> jmsMessageTransformers;
 
     public FailedMessageCreator(FailedMessage failedMessage) {
+        this(failedMessage, Collections.singletonList(new FailedMessageTransformer()));
+    }
+
+    public FailedMessageCreator(FailedMessage failedMessage, List<JmsMessageTransformer<TextMessage, FailedMessage>> jmsMessageTransformers) {
         this.failedMessage = failedMessage;
-        this.failedMessageDataProviders = Collections.singletonList(new FailedMessageDataProvider());
+        this.jmsMessageTransformers = jmsMessageTransformers;
+
     }
 
     @Override
     public Message createMessage(Session session) throws JMSException {
         TextMessage textMessage = session.createTextMessage();
-        for (FailedMessageDataProvider failedMessageDataProvider : failedMessageDataProviders) {
-            failedMessageDataProvider.provide(textMessage, failedMessage);
+        for (JmsMessageTransformer<TextMessage, FailedMessage> jmsMessageTransformer : jmsMessageTransformers) {
+            jmsMessageTransformer.transform(textMessage, failedMessage);
         }
         return textMessage;
     }

--- a/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageTransformerTest.java
+++ b/core/jms/src/test/java/uk/gov/dwp/queue/triage/core/jms/FailedMessageTransformerTest.java
@@ -13,14 +13,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class FailedMessageDataProviderTest {
+public class FailedMessageTransformerTest {
 
     private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
 
     private final FailedMessage failedMessage = mock(FailedMessage.class);
     private final TextMessage textMessage = mock(TextMessage.class);
 
-    private final FailedMessageDataProvider underTest = new FailedMessageDataProvider();
+    private final FailedMessageTransformer underTest = new FailedMessageTransformer();
 
     @Test
     public void processingContinuesObjectPropertyCannotBeWritten() throws JMSException {
@@ -29,7 +29,7 @@ public class FailedMessageDataProviderTest {
         when(failedMessage.getFailedMessageId()).thenReturn(FAILED_MESSAGE_ID);
         doThrow(new JMSException("Arrrghhhhh")).when(textMessage).setObjectProperty("foo", "bar");
 
-        underTest.provide(textMessage, failedMessage);
+        underTest.transform(textMessage, failedMessage);
 
         verify(textMessage).setText("content");
         verify(textMessage).setObjectProperty("foo", "bar");


### PR DESCRIPTION
- Renamed `FailedMessageDataProvider` to `FailedMessageTransformer`
- Renamed `JmsMessageDataProvider` to `JmsMessageTransformer`