### PR TITLE
#162 - Vault resolved values which need to be bound to fields of type String.class

### DIFF
--- a/core/vault/src/main/java/uk/gov/dwp/vault/config/VaultAutoConfiguration.java
+++ b/core/vault/src/main/java/uk/gov/dwp/vault/config/VaultAutoConfiguration.java
@@ -10,10 +10,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.Ordered;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
+
 import uk.gov.dwp.vault.SensitiveConfigValueLookupRegistry;
 import uk.gov.dwp.vault.SensitiveConfigValueLookupStrategy;
 import uk.gov.dwp.vault.SingleValueVaultLookupStrategy;
@@ -87,6 +90,23 @@ public class VaultAutoConfiguration {
     @DependsOn("vaultPropertySource")
     public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
         return new PropertySourcesPlaceholderConfigurer();
+    }
+
+
+    private Converter<char[], String> chararacterArrayToStringConverter() {
+        return new Converter<char[], String>() {
+            @Override
+            public String convert(char[] source) {
+                return new String(source);
+            }
+        };
+    }
+
+    @Bean
+    public ConversionService conversionService() {
+        DefaultConversionService defaultConversionService = new DefaultConversionService();
+        defaultConversionService.addConverter(chararacterArrayToStringConverter());
+        return defaultConversionService;
     }
 
 

--- a/core/vault/src/test/java/uk/gov/dwp/vault/config/QueueTriageVaultAutoConfigurationWhenVaultIsEnabledIntegrationTest.java
+++ b/core/vault/src/test/java/uk/gov/dwp/vault/config/QueueTriageVaultAutoConfigurationWhenVaultIsEnabledIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -29,6 +30,9 @@ public class QueueTriageVaultAutoConfigurationWhenVaultIsEnabledIntegrationTest 
     @Autowired
     public SensitiveConfigValueLookupRegistry sensitiveConfigValueLookupRegistry;
 
+    @Autowired
+    public ConversionService conversionService;
+
     @Test
     public void ensureThatWhenConfiguringVault_thatTheOrderOfTheServicesAreWhatWeExpect() throws Exception {
         assertNotNull(vaultProperties);
@@ -43,5 +47,16 @@ public class QueueTriageVaultAutoConfigurationWhenVaultIsEnabledIntegrationTest 
         assertNotNull(sensitiveConfigValueLookupRegistry);
     }
 
+    @Test
+    public void ensureConversionServiceHasAConverterRegisteredToConvertFromCharArrayToString() throws Exception {
+        assertNotNull("There needs to be a registered ConversionService bean instance", conversionService);
 
+        assertThat("There is no converter registered which can convert from char[] to String. "
+                   + "This is necessary for the implementation of the VaultPropertySource, which returns a char[] for storing "
+                   + "passwords in ConfigurationProperties POJO's. This is mainly used for instances where Vault resolved values "
+                   + "need to be converted into String for POJO's that we have no control over. For an example, "
+                   + "see the org.springframework.boot.context.embedded.Ssl.java which stores the keyStorePassword field as a String.",
+                   conversionService.canConvert(char[].class, String.class),
+                   is(true));
+    }
 }


### PR DESCRIPTION
Adding in a Converter to transform char[] into String for *Properties objects that require passwords to be set as String. See org.springframework.boot.context.embedded.Ssl.java as an example