### PR TITLE
Issue 99/display message details

### DIFF
--- a/common/jgiven/src/main/java/uk/gov/dwp/queue/triage/jgiven/ReflectionArgumentFormatter.java
+++ b/common/jgiven/src/main/java/uk/gov/dwp/queue/triage/jgiven/ReflectionArgumentFormatter.java
@@ -16,6 +16,6 @@ public class ReflectionArgumentFormatter implements ArgumentFormatter<Object> {
                     .map(item -> format(item, fieldsToInclude))
                     .collect(joining(", and "));
         }
-        return ReflectionToStringBuilder.toString(argumentToFormat, toStringWithFields(fieldsToInclude));
+        return ReflectionToStringBuilder.toString(argumentToFormat, fieldsToInclude != null ? toStringWithFields(fieldsToInclude) : null);
     }
 }

--- a/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseMatcher.java
+++ b/core/client-test-support/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseMatcher.java
@@ -4,6 +4,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsAnything;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -18,8 +19,8 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
     private Matcher<String> content = new IsAnything<>();
     private Matcher<String> broker = new IsAnything<>();
     private Matcher<Optional<String>> destination = new IsAnything<>();
-    private Matcher<Instant> sentDateTime = new IsAnything<>();
-    private Matcher<Instant> failedDateTime = new IsAnything<>();
+    private Matcher<FailedMessageStatus> status = new IsAnything<>();
+    private Matcher<Instant> statusDateTime = new IsAnything<>();
     private Matcher<Iterable<? extends String>> labels = new IsAnything<>();
 
     private SearchFailedMessageResponseMatcher() {
@@ -54,23 +55,18 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
         return this;
     }
 
-    public SearchFailedMessageResponseMatcher withSentDateTime(Instant sentAt) {
-        this.sentDateTime = equalTo(sentAt);
+    public SearchFailedMessageResponseMatcher withStatus(FailedMessageStatus status) {
+        this.status = equalTo(status);
         return this;
     }
 
-    public SearchFailedMessageResponseMatcher withSentDateTime(Matcher<Instant> sentDateTimeMatcher) {
-        this.sentDateTime = sentDateTimeMatcher;
+    public SearchFailedMessageResponseMatcher withStatusDateTime(Instant statusDateTime) {
+        this.statusDateTime = equalTo(statusDateTime);
         return this;
     }
 
-    public SearchFailedMessageResponseMatcher withFailedDateTime(Instant failedDateTime) {
-        this.failedDateTime = equalTo(failedDateTime);
-        return this;
-    }
-
-    public SearchFailedMessageResponseMatcher withFailedDateTime(Matcher<Instant> failedAtMatcher) {
-        this.failedDateTime = failedAtMatcher;
+    public SearchFailedMessageResponseMatcher withStatusDateTime(Matcher<Instant> statusDateTimeMatcher) {
+        this.statusDateTime = statusDateTimeMatcher;
         return this;
     }
 
@@ -86,8 +82,8 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
                 && content.matches(item.getContent())
                 && broker.matches(item.getBroker())
                 && destination.matches(item.getDestination())
-                && sentDateTime.matches(item.getSentDateTime())
-                && failedDateTime.matches(item.getLastFailedDateTime())
+                && status.matches(item.getStatus())
+                && statusDateTime.matches(item.getStatusDateTime())
                 && labels.matches(item.getLabels())
                 ;
     }
@@ -99,8 +95,8 @@ public class SearchFailedMessageResponseMatcher extends TypeSafeMatcher<SearchFa
         appendIfMatcherIsNotIsAnything(" content is ", content, description);
         appendIfMatcherIsNotIsAnything(" broker is ", broker, description);
         appendIfMatcherIsNotIsAnything(" destination is ", destination, description);
-        appendIfMatcherIsNotIsAnything(" sentDateTime is ", sentDateTime, description);
-        appendIfMatcherIsNotIsAnything(" failedDateTime is ", failedDateTime, description);
+        appendIfMatcherIsNotIsAnything(" status is ", status, description);
+        appendIfMatcherIsNotIsAnything(" statusDateTime is ", statusDateTime, description);
         appendIfMatcherIsNotIsAnything(" labels is ", labels, description);
     }
 

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageStatus.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/FailedMessageStatus.java
@@ -1,7 +1,17 @@
 package uk.gov.dwp.queue.triage.core.client;
 
 public enum FailedMessageStatus {
-    FAILED,
-    RESENDING,
-    SENT
+    FAILED("Failed"),
+    RESENDING("Resending"),
+    SENT("Sent");
+
+    private final String description;
+
+    FailedMessageStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
+++ b/core/client/src/main/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.dwp.queue.triage.core.client.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import javax.validation.constraints.NotNull;
@@ -17,10 +18,8 @@ public class SearchFailedMessageResponse {
     @NotNull
     private final String broker;
     private final String destination;
-    @NotNull
-    private final Instant sentDateTime;
-    @NotNull
-    private final Instant lastFailedDateTime;
+    private final FailedMessageStatus status;
+    private final Instant statusDateTime;
     private final String content;
     private final Set<String> labels;
 
@@ -32,16 +31,16 @@ public class SearchFailedMessageResponse {
                                         @JsonProperty("jmsMessageId") String jmsMessageId,
                                         @JsonProperty("broker") String broker,
                                         @JsonProperty("destination") String destination,
-                                        @JsonProperty("sentDateTime") Instant sentDateTime,
-                                        @JsonProperty("failedDateTime") Instant lastFailedDateTime,
+                                        @JsonProperty("status") FailedMessageStatus status,
+                                        @JsonProperty("statusDateTime") Instant statusDateTime,
                                         @JsonProperty("content") String content,
                                         @JsonProperty("labels") Set<String> labels) {
         this.failedMessageId = failedMessageId;
         this.jmsMessageId = jmsMessageId;
         this.broker = broker;
         this.destination = destination;
-        this.sentDateTime = sentDateTime;
-        this.lastFailedDateTime = lastFailedDateTime;
+        this.status = status;
+        this.statusDateTime = statusDateTime;
         this.content = content;
         this.labels = labels;
     }
@@ -62,12 +61,12 @@ public class SearchFailedMessageResponse {
         return Optional.ofNullable(destination);
     }
 
-    public Instant getSentDateTime() {
-        return sentDateTime;
+    public FailedMessageStatus getStatus() {
+        return status;
     }
 
-    public Instant getLastFailedDateTime() {
-        return lastFailedDateTime;
+    public Instant getStatusDateTime() {
+        return statusDateTime;
     }
 
     public String getContent() {
@@ -85,8 +84,8 @@ public class SearchFailedMessageResponse {
                 ", jmsMessageId='" + jmsMessageId + '\'' +
                 ", broker='" + broker + '\'' +
                 ", destination=" + destination +
-                ", sentDateTime=" + sentDateTime +
-                ", lastFailedDateTime=" + lastFailedDateTime +
+                ", status=" + status +
+                ", statusDateTime=" + statusDateTime +
                 ", content='" + content + '\'' +
                 ", labels=" + labels +
                 '}';
@@ -98,8 +97,8 @@ public class SearchFailedMessageResponse {
         private String jmsMessageId;
         private String broker;
         private String destination;
-        private Instant sentDateTime;
-        private Instant failedDateTime;
+        private FailedMessageStatus status;
+        private Instant statusDateTime;
         private String content;
         private Set<String> labels = new HashSet<>();
 
@@ -126,13 +125,13 @@ public class SearchFailedMessageResponse {
             return this;
         }
 
-        public SearchFailedMessageResponseBuilder withSentDateTime(Instant sentDateTime) {
-            this.sentDateTime = sentDateTime;
+        public SearchFailedMessageResponseBuilder withStatus(FailedMessageStatus status) {
+            this.status = status;
             return this;
         }
 
-        public SearchFailedMessageResponseBuilder withFailedDateTime(Instant failedDateTime) {
-            this.failedDateTime = failedDateTime;
+        public SearchFailedMessageResponseBuilder withStatusDateTime(Instant statusDateTime) {
+            this.statusDateTime = statusDateTime;
             return this;
         }
 
@@ -147,7 +146,7 @@ public class SearchFailedMessageResponse {
         }
 
         public SearchFailedMessageResponse build() {
-            return new SearchFailedMessageResponse(failedMessageId, jmsMessageId, broker, destination, sentDateTime, failedDateTime, content, labels);
+            return new SearchFailedMessageResponse(failedMessageId, jmsMessageId, broker, destination, status, statusDateTime, content, labels);
         }
     }
 }

--- a/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseTest.java
+++ b/core/client/src/test/java/uk/gov/dwp/queue/triage/core/client/search/SearchFailedMessageResponseTest.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.core.client.search;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.SearchFailedMessageResponseBuilder;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
@@ -34,9 +35,9 @@ public class SearchFailedMessageResponseTest {
             .withBroker(BROKER_NAME)
             .withContent(SOME_CONTENT)
             .withFailedMessageId(FAILED_MESSAGE_ID)
-            .withFailedDateTime(NOW.plusSeconds(1))
             .withJmsMessageId(JMS_MESSAGE_ID)
-            .withSentDateTime(NOW);
+            .withStatus(FailedMessageStatus.FAILED)
+            .withStatusDateTime(NOW);
 
     @Test
     public void serialiseAndDeserialiseObjectWithDefaults() throws IOException {
@@ -47,10 +48,10 @@ public class SearchFailedMessageResponseTest {
                 .withBroker(equalTo(BROKER_NAME))
                 .withContent(equalTo(SOME_CONTENT))
                 .withDestination(equalTo(Optional.empty()))
-                .withFailedDateTime(NOW.plusSeconds(1))
                 .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
                 .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
-                .withSentDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withLabels(emptyIterable())
         ));
     }
@@ -66,13 +67,11 @@ public class SearchFailedMessageResponseTest {
                 .withBroker(equalTo(BROKER_NAME))
                 .withContent(equalTo(SOME_CONTENT))
                 .withDestination(equalTo(Optional.of(DESTINATION_NAME)))
-                .withFailedDateTime(NOW.plusSeconds(1))
                 .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
                 .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
-                .withSentDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withLabels(contains("foo"))
         ));
     }
-
-
 }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapter.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.core.search;
 
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessage;
+import uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter;
 
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -12,10 +13,10 @@ public class SearchFailedMessageResponseAdapter {
                 .withBroker(failedMessage.getDestination().getBrokerName())
                 .withContent(failedMessage.getContent())
                 .withDestination(failedMessage.getDestination().getName().orElse(null))
-                .withFailedDateTime(failedMessage.getFailedAt())
+                .withStatus(FailedMessageStatusAdapter.toFailedMessageStatus(failedMessage.getStatusHistoryEvent().getStatus()))
+                .withStatusDateTime(failedMessage.getStatusHistoryEvent().getEffectiveDateTime())
                 .withFailedMessageId(failedMessage.getFailedMessageId())
                 .withJmsMessageId(failedMessage.getJmsMessageId())
-                .withSentDateTime(failedMessage.getSentAt())
                 .withLabels(failedMessage.getLabels())
                 .build();
     }

--- a/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapter.java
+++ b/core/search/src/main/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapter.java
@@ -4,8 +4,10 @@ import org.bson.Document;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
+import static uk.gov.dwp.queue.triage.core.domain.FailedMessageStatusAdapter.toFailedMessageStatus;
 
 public class MongoSearchResponseAdapter {
 
@@ -16,14 +18,15 @@ public class MongoSearchResponseAdapter {
     }
 
     public SearchFailedMessageResponse toResponse(Document document) {
-        Destination destination = failedMessageConverter.getDestination(document);
+        final Destination destination = failedMessageConverter.getDestination(document);
+        final StatusHistoryEvent statusHistoryEvent = failedMessageConverter.getStatusHistoryEvent(document);
         return newSearchFailedMessageResponse()
                 .withFailedMessageId(failedMessageConverter.getFailedMessageId(document))
                 .withBroker(destination.getBrokerName())
                 .withDestination(destination.getName().orElse(null))
                 .withContent(failedMessageConverter.getContent(document))
-                .withSentDateTime(failedMessageConverter.getSentDateTime(document))
-                .withFailedDateTime(failedMessageConverter.getFailedDateTime(document))
+                .withStatus(toFailedMessageStatus(statusHistoryEvent.getStatus()))
+                .withStatusDateTime(statusHistoryEvent.getEffectiveDateTime())
                 .build();
 
     }

--- a/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapterTest.java
+++ b/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/SearchFailedMessageResponseAdapterTest.java
@@ -1,6 +1,7 @@
 package uk.gov.dwp.queue.triage.core.search;
 
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
 import uk.gov.dwp.queue.triage.core.domain.FailedMessageBuilder;
 import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
@@ -30,9 +31,7 @@ public class SearchFailedMessageResponseAdapterTest {
     private final FailedMessageBuilder failedMessageBuilder = FailedMessageBuilder.newFailedMessage()
             .withContent(SOME_CONTENT)
             .withFailedMessageId(FAILED_MESSAGE_ID)
-            .withFailedDateTime(NOW.plusSeconds(1))
             .withJmsMessageId(JMS_MESSAGE_ID)
-            .withSentDateTime(NOW)
             .withProperties(Collections.singletonMap("foo", "bar"))
             .withLabel("foo")
             .withStatusHistoryEvent(new StatusHistoryEvent(FAILED, NOW));
@@ -45,10 +44,10 @@ public class SearchFailedMessageResponseAdapterTest {
                 .withBroker(equalTo(BROKER_NAME))
                 .withContent(equalTo(SOME_CONTENT))
                 .withDestination(equalTo(Optional.empty()))
-                .withFailedDateTime(NOW.plusSeconds(1))
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
                 .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
-                .withSentDateTime(NOW)
                 .withLabels(contains("foo"))
         ));
     }
@@ -59,10 +58,10 @@ public class SearchFailedMessageResponseAdapterTest {
                 .withBroker(equalTo(BROKER_NAME))
                 .withContent(equalTo(SOME_CONTENT))
                 .withDestination(equalTo(Optional.of(DESTINATION_NAME)))
-                .withFailedDateTime(NOW.plusSeconds(1))
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withFailedMessageId(equalTo(FAILED_MESSAGE_ID))
                 .withJmsMessageId(equalTo(JMS_MESSAGE_ID))
-                .withSentDateTime(NOW)
                 .withLabels(contains("foo"))
         ));
     }

--- a/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapterTest.java
+++ b/core/search/src/test/java/uk/gov/dwp/queue/triage/core/search/mongo/MongoSearchResponseAdapterTest.java
@@ -4,9 +4,11 @@ import org.bson.Document;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.dao.mongo.FailedMessageConverter;
 import uk.gov.dwp.queue.triage.core.domain.Destination;
+import uk.gov.dwp.queue.triage.core.domain.StatusHistoryEvent;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 
 import java.time.Instant;
@@ -28,12 +30,10 @@ public class MongoSearchResponseAdapterTest {
 
     @Test
     public void convertBasicDBbjectToSearchResponse() {
-        when(failedMessageConverter.getDestination(document)).thenReturn(
-                new Destination("broker-name", Optional.of("queue-name")));
+        when(failedMessageConverter.getDestination(document)).thenReturn(new Destination("broker-name", Optional.of("queue-name")));
+        when(failedMessageConverter.getStatusHistoryEvent(document)).thenReturn(new StatusHistoryEvent(StatusHistoryEvent.Status.FAILED, NOW));
         when(failedMessageConverter.getFailedMessageId(document)).thenReturn(FAILED_MESSAGE_ID);
         when(failedMessageConverter.getContent(document)).thenReturn("some-content");
-        when(failedMessageConverter.getFailedDateTime(document)).thenReturn(NOW);
-        when(failedMessageConverter.getSentDateTime(document)).thenReturn(NOW);
 
         SearchFailedMessageResponse response = underTest.toResponse(document);
 
@@ -47,8 +47,8 @@ public class MongoSearchResponseAdapterTest {
             protected boolean matchesSafely(SearchFailedMessageResponse response) {
                 return FAILED_MESSAGE_ID.equals(response.getFailedMessageId()) &&
                         "some-content".equals(response.getContent()) &&
-                        NOW.equals(response.getLastFailedDateTime()) &&
-                        NOW.equals(response.getSentDateTime()) &&
+                        NOW.equals(response.getStatusDateTime()) &&
+                        FailedMessageStatus.FAILED.equals(response.getStatus()) &&
                         "broker-name".equals(response.getBroker()) &&
                         Optional.of("queue-name").equals(response.getDestination());
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,8 +29,8 @@ include 'common:id',
         'core:vault',
         'web:component-test',
         'web:mustache',
-        'web:web-server',
-        'web:spring-security'
+        'web:spring-security',
+        'web:web-server'
 
 
 

--- a/web/component-test/component-test.gradle
+++ b/web/component-test/component-test.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-webapp'
     testImplementation 'org.hibernate:hibernate-validator'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver'
+    testImplementation 'org.valid4j:json-path-matchers'
     testImplementation 'org.yaml:snakeyaml'
 }
 

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/configuration/CoreClientConfiguration.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/configuration/CoreClientConfiguration.java
@@ -7,6 +7,7 @@ import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.delete.DeleteFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
 
 import static org.mockito.Mockito.mock;
 
@@ -32,5 +33,10 @@ public class CoreClientConfiguration {
     @Bean
     public ResendFailedMessageClient resendFailedMessageClient() {
         return mock(ResendFailedMessageClient.class);
+    }
+
+    @Bean
+    public FailedMessageStatusHistoryClient failedMessageStatusHistoryClient() {
+        return mock(FailedMessageStatusHistoryClient.class);
     }
 }

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/FailedMessageListThenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/list/FailedMessageListThenStage.java
@@ -20,7 +20,7 @@ public class FailedMessageListThenStage extends ThenStage<FailedMessageListThenS
         return this;
     }
 
-    public FailedMessageListThenStage theMessageListContainsAFailedMessageWithId(FailedMessageId failedMessageId) throws InterruptedException {
+    public FailedMessageListThenStage theMessageListContainsAFailedMessageWithId(FailedMessageId failedMessageId) {
         LOGGER.debug("Asserting FailedMessageId: {} is in the MessageList", failedMessageId);
         Selenide.$(By.cssSelector("tr[recid='" + failedMessageId.toString() + "']")).should(exist);
         return this;

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/LoginApiGivenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/LoginApiGivenStage.java
@@ -1,0 +1,48 @@
+package uk.gov.dwp.queue.triage.web.component.login;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import uk.gov.dwp.queue.triage.jgiven.GivenStage;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+@JGivenStage
+public class LoginApiGivenStage extends GivenStage<LoginApiGivenStage> {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    @ExpectedScenarioState
+    private HttpHeaders httpHeaders;
+
+    public LoginApiGivenStage theUserHasSuccessfullyLoggedOn() {
+            final ResponseEntity<Object> exchange = testRestTemplate.exchange(
+                    "/web/login?username={username}&password={password}",
+                    HttpMethod.POST,
+                    new HttpEntity<>(Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)),
+                    new ParameterizedTypeReference<Object>() {},
+                    new HashMap<String, String>() {{
+                        put("username", UserFixture.USERNAME);
+                        put("password", UserFixture.PASSWORD);
+                    }}
+            );
+            httpHeaders = extractCookies(exchange);
+            return self();
+    }
+
+    private HttpHeaders extractCookies(ResponseEntity<Object> exchange) {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        exchange.getHeaders()
+                .get(HttpHeaders.SET_COOKIE)
+                .forEach(cookie -> httpHeaders.set(HttpHeaders.COOKIE, cookie));
+        return httpHeaders;
+    }
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/LoginGivenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/LoginGivenStage.java
@@ -5,6 +5,9 @@ import com.tngtech.jgiven.integration.spring.JGivenStage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
+import static uk.gov.dwp.queue.triage.web.component.login.UserFixture.PASSWORD;
+import static uk.gov.dwp.queue.triage.web.component.login.UserFixture.USERNAME;
+
 @JGivenStage
 public class LoginGivenStage extends Stage<LoginGivenStage> {
 
@@ -13,8 +16,8 @@ public class LoginGivenStage extends Stage<LoginGivenStage> {
 
     public LoginGivenStage theUserHasSuccessfullyLoggedOn() {
         LoginPage.openLoginPage(environment)
-                .enterUsername("bobbuilder")
-                .enterPassword("fixit")
+                .enterUsername(USERNAME)
+                .enterPassword(PASSWORD)
                 .submit();
         return this;
     }

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/UserFixture.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/login/UserFixture.java
@@ -1,0 +1,7 @@
+package uk.gov.dwp.queue.triage.web.component.login;
+
+public class UserFixture {
+
+    public static final String USERNAME = "bobbuilder";
+    public static final String PASSWORD = "fixit";
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryGivenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryGivenStage.java
@@ -1,0 +1,28 @@
+package uk.gov.dwp.queue.triage.web.component.status;
+
+import com.tngtech.jgiven.annotation.Table;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.GivenStage;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+
+@JGivenStage
+public class StatusHistoryGivenStage extends GivenStage<StatusHistoryGivenStage> {
+
+    @Autowired
+    private FailedMessageStatusHistoryClient failedMessageStatusHistoryClient;
+
+    // Given a Failed Message With Id {} with Status {} on {} and with Status {} on {}
+    public StatusHistoryGivenStage aFailedMessageWithId$Has$(
+            FailedMessageId failedMessageId,
+            @Table StatusHistoryResponse...statusHistoryResponses) {
+        when(failedMessageStatusHistoryClient.getStatusHistory(failedMessageId)).thenReturn(Arrays.asList(statusHistoryResponses));
+        return self();
+    }
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryThenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryThenStage.java
@@ -1,0 +1,28 @@
+package uk.gov.dwp.queue.triage.web.component.status;
+
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.hamcrest.Matcher;
+import org.springframework.http.ResponseEntity;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.ThenStage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@JGivenStage
+public class StatusHistoryThenStage extends ThenStage<StatusHistoryThenStage> {
+
+    @ProvidedScenarioState
+    private ResponseEntity<String> statusHistoryListItemsResponse;
+
+    public StatusHistoryThenStage theStatusHistoryResponseForFailedMessage(
+            FailedMessageId failedMessageId,
+            Matcher<Object> statusHistoryListItemMatcher) {
+        assertThat(statusHistoryListItemsResponse.getStatusCodeValue(), is(200));
+        assertThat(statusHistoryListItemsResponse.getBody(), statusHistoryListItemMatcher);
+        return this;
+    }
+
+
+}

--- a/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryWhenStage.java
+++ b/web/component-test/src/main/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryWhenStage.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.web.component.status;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.jgiven.WhenStage;
+
+import java.util.Collections;
+import java.util.Objects;
+
+@JGivenStage
+public class StatusHistoryWhenStage extends WhenStage<StatusHistoryWhenStage> {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    @ProvidedScenarioState
+    private HttpHeaders httpHeaders;
+    @ExpectedScenarioState
+    private ResponseEntity<String> statusHistoryListItemsResponse;
+
+    public StatusHistoryWhenStage theStatusHistoryIsRequestedForFailedMessage$(FailedMessageId failedMessageId) {
+        Objects.requireNonNull(httpHeaders, "httpHeaders are not set.  Try executing LoginApiGivenStage#theUserHasSuccessfullyLoggedOn()");
+        statusHistoryListItemsResponse = testRestTemplate.exchange(
+                "/web/api/failed-messages/status-history/{failedMessageId}",
+                HttpMethod.POST,
+                new HttpEntity<>(httpHeaders),
+                new ParameterizedTypeReference<String>() {},
+                Collections.singletonMap("failedMessageId", failedMessageId));
+        return self();
+    }
+}

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/delete/DeleteFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/delete/DeleteFailedMessageComponentTest.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.web.component.delete;
 
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
@@ -9,7 +10,6 @@ import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
 
-import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -23,21 +23,21 @@ public class DeleteFailedMessageComponentTest extends WebComponentTest<ListFaile
     private LoginGivenStage loginGivenStage;
 
     @Test
-    public void deleteFailedMessages() throws Exception {
+    public void deleteFailedMessages() {
         given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
                 .withDestination("topic-name")
-                .withSentDateTime(NOW.minus(1, HOURS))
-                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
         );
         given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/labels/LabelManagementComponentTest.java
@@ -3,6 +3,7 @@ package uk.gov.dwp.queue.triage.web.component.labels;
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Ignore;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.SimpleBaseWebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
@@ -10,7 +11,6 @@ import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
 
-import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -29,21 +29,21 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
     private LabelManagementThenStage labelManagementThenStage;
 
     @Test
-    public void addSingleLabelToAFailedMessage() throws Exception {
+    public void addSingleLabelToAFailedMessage() {
         listFailedMessagesStage.given().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
                 .withDestination("topic-name")
-                .withSentDateTime(NOW.minus(1, HOURS))
-                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
         );
         listFailedMessagesStage.given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);
@@ -64,16 +64,16 @@ public class LabelManagementComponentTest extends SimpleBaseWebComponentTest<Lab
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         listFailedMessagesStage.given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
                 .withDestination("topic-name")
-                .withSentDateTime(NOW.minus(1, HOURS))
-                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
         );
         listFailedMessagesStage.given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/list/ViewFailedMessagesComponentTest.java
@@ -2,13 +2,13 @@ package uk.gov.dwp.queue.triage.web.component.list;
 
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
 
-import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -26,16 +26,16 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
                 .withDestination("topic-name")
-                .withSentDateTime(NOW.minus(1, HOURS))
-                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
         );
         given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);
@@ -48,7 +48,7 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
     }
 
     @Test
-    public void reloadButtonRefreshesTheMessageList() throws Exception {
+    public void reloadButtonRefreshesTheMessageList() {
 
         given().theSearchResultsWillContainNoFailedMessages();
         loginGivenStage.and().theUserHasSuccessfullyLoggedOn();
@@ -59,8 +59,8 @@ public class ViewFailedMessagesComponentTest extends WebComponentTest<ListFailed
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1);

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/resend/ResendFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/resend/ResendFailedMessageComponentTest.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.queue.triage.web.component.resend;
 
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
@@ -9,7 +10,6 @@ import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
 
 import java.time.Instant;
 
-import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
 
@@ -28,16 +28,16 @@ public class ResendFailedMessageComponentTest extends WebComponentTest<ListFaile
                 .withFailedMessageId(FAILED_MESSAGE_ID_1)
                 .withBroker("main-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(NOW.minus(1, MINUTES))
-                .withFailedDateTime(NOW)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(NOW)
                 .withContent("Boom")
         );
         given().and().aFailedMessage$Exists(newSearchFailedMessageResponse()
                 .withFailedMessageId(FAILED_MESSAGE_ID_2)
                 .withBroker("another-broker")
                 .withDestination("topic-name")
-                .withSentDateTime(NOW.minus(1, HOURS))
-                .withFailedDateTime(NOW.minus(2, MINUTES))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(NOW.minus(2, MINUTES))
                 .withContent("Failure")
         );
         given().and().theSearchResultsWillContainFailedMessages$(FAILED_MESSAGE_ID_1, FAILED_MESSAGE_ID_2);

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/search/SearchFailedMessageComponentTest.java
@@ -2,11 +2,14 @@ package uk.gov.dwp.queue.triage.web.component.search;
 
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
 import uk.gov.dwp.queue.triage.web.component.list.FailedMessageListThenStage;
 import uk.gov.dwp.queue.triage.web.component.list.ListFailedMessagesStage;
 import uk.gov.dwp.queue.triage.web.component.login.LoginGivenStage;
+
+import java.time.Instant;
 
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageRequestMatcher.aSearchRequestMatchingAnyCriteria;
 import static uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse.newSearchFailedMessageResponse;
@@ -19,7 +22,7 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
     private LoginGivenStage loginGivenStage;
 
     @Test
-    public void searchAllFields() throws Exception {
+    public void searchAllFields() {
         loginGivenStage.given().theUserHasSuccessfullyLoggedOn();
         given().and().theUserNavigatesToTheFailedMessagesPage();
         given().and().queueTriageCoreWillRespondTo(
@@ -32,6 +35,8 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
                         .withBroker("main-broker")
                         .withDestination("queue-name")
                         .withContent("This message contains some-text")
+                        .withStatus(FailedMessageStatus.FAILED)
+                        .withStatusDateTime(Instant.now())
                         .build()
         );
 
@@ -41,7 +46,7 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
     }
 
     @Test
-    public void searchForASpecificField() throws Exception {
+    public void searchForASpecificField() {
         loginGivenStage.given().theUserHasSuccessfullyLoggedOn();
         given().and().theUserNavigatesToTheFailedMessagesPage();
         given().and().queueTriageCoreWillRespondTo(
@@ -51,6 +56,8 @@ public class SearchFailedMessageComponentTest extends WebComponentTest<ListFaile
                         .withBroker("main-broker")
                         .withDestination("queue-name")
                         .withContent("This message contains some-text")
+                        .withStatus(FailedMessageStatus.FAILED)
+                        .withStatusDateTime(Instant.now())
                         .build()
         );
 

--- a/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryApiComponentTest.java
+++ b/web/component-test/src/test/java/uk/gov/dwp/queue/triage/web/component/status/StatusHistoryApiComponentTest.java
@@ -1,0 +1,53 @@
+package uk.gov.dwp.queue.triage.web.component.status;
+
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.component.WebComponentTest;
+import uk.gov.dwp.queue.triage.web.component.login.LoginApiGivenStage;
+import uk.gov.dwp.queue.triage.web.server.api.Constants;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.valid4j.matchers.jsonpath.JsonPathMatchers.isJson;
+import static org.valid4j.matchers.jsonpath.JsonPathMatchers.withJsonPath;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.FAILED;
+import static uk.gov.dwp.queue.triage.core.client.FailedMessageStatus.RESENDING;
+
+public class StatusHistoryApiComponentTest extends WebComponentTest<StatusHistoryGivenStage, StatusHistoryWhenStage, StatusHistoryThenStage> {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID_1 = FailedMessageId.newFailedMessageId();
+    private static final Instant NOW = Instant.now();
+
+    @ScenarioStage
+    private LoginApiGivenStage loginApiGivenStage;
+
+    @Test
+    public void requestStatusHistoryForFailedMessage() {
+        given().aFailedMessageWithId$Has$(
+                FAILED_MESSAGE_ID_1,
+                new StatusHistoryResponse(FAILED, NOW),
+                new StatusHistoryResponse(RESENDING, NOW.plusSeconds(5)));
+        loginApiGivenStage.given().and().theUserHasSuccessfullyLoggedOn();
+        when().theStatusHistoryIsRequestedForFailedMessage$(FAILED_MESSAGE_ID_1);
+        then().theStatusHistoryResponseForFailedMessage(FAILED_MESSAGE_ID_1, isJson(allOf(
+                withJsonPath("$.records", hasSize(2)),
+                withJsonPath("$.status", equalTo("success")),
+                withJsonPath("$.total", equalTo(2)))
+        ));
+        then().theStatusHistoryResponseForFailedMessage(FAILED_MESSAGE_ID_1, isJson(allOf(
+                withJsonPath("$.records[0].recid", equalTo(NOW.toEpochMilli() + "-failed")),
+                withJsonPath("$.records[0].status", equalTo("Failed")),
+                withJsonPath("$.records[0].effectiveDateTime", equalTo(Constants.toIsoDateTimeWithMs(NOW).get()))
+        )));
+        then().theStatusHistoryResponseForFailedMessage(FAILED_MESSAGE_ID_1, isJson(allOf(
+                withJsonPath("$.records[1].recid", equalTo(NOW.plusSeconds(5).toEpochMilli() + "-resending")),
+                withJsonPath("$.records[1].status", equalTo("Resending")),
+                withJsonPath("$.records[1].effectiveDateTime", equalTo(Constants.toIsoDateTimeWithMs(NOW.plusSeconds(5)).get()))
+        )));
+    }
+}

--- a/web/mustache/src/main/java/uk/gov/dwp/queue/triage/web/common/mustache/PageMessageBodyWriter.java
+++ b/web/mustache/src/main/java/uk/gov/dwp/queue/triage/web/common/mustache/PageMessageBodyWriter.java
@@ -25,7 +25,7 @@ import static javax.ws.rs.core.Response.serverError;
 @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML})
 public class PageMessageBodyWriter implements MessageBodyWriter<Page> {
     private static final Logger logger = LoggerFactory.getLogger(PageMessageBodyWriter.class);
-    public static final String TEMPLATE_ERROR_MSG =
+    private static final String TEMPLATE_ERROR_MSG =
             "<html>" +
                     "<head><title>Template Error</title></head>" +
                     "<body><h1>Template Error</h1><p>Something went wrong rendering the page</p></body>" +

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/Constants.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/Constants.java
@@ -1,0 +1,25 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ofPattern;
+
+public final class Constants {
+
+    private static final DateTimeFormatter ISO_DATE_TIME_WITH_MS = ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC);
+
+    private Constants() {
+    }
+
+    public static Optional<String> toIsoDateTimeWithMs(Instant instant) {
+        return Optional.ofNullable(instant).map(ISO_DATE_TIME_WITH_MS::format);
+    }
+
+    public static Optional<Instant> toInstantFromIsoDateTime(String instantAsString) {
+        return Optional.ofNullable(instantAsString).map(instant -> ISO_DATE_TIME_WITH_MS.parse(instant, Instant::from));
+    }
+
+}

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryListItem.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryListItem.java
@@ -1,0 +1,30 @@
+package uk.gov.dwp.queue.triage.web.server.api.status;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.web.server.api.Constants;
+
+class StatusHistoryListItem {
+
+    private final StatusHistoryResponse statusHistoryResponse;
+
+    StatusHistoryListItem(StatusHistoryResponse statusHistoryResponse) {
+        this.statusHistoryResponse = statusHistoryResponse;
+    }
+
+    @JsonProperty("recid")
+    public String getRecId() {
+        // Could this just be a UUID?
+        return String.valueOf(statusHistoryResponse.getEffectiveDateTime().toEpochMilli()) + "-" + statusHistoryResponse.getStatus().toString().toLowerCase();
+    }
+
+    @JsonProperty
+    public String getStatus() {
+        return statusHistoryResponse.getStatus().getDescription();
+    }
+
+    @JsonProperty
+    public String getEffectiveDateTime() {
+        return Constants.toIsoDateTimeWithMs(statusHistoryResponse.getEffectiveDateTime()).orElse(null);
+    }
+}

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryResource.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryResource.java
@@ -1,0 +1,38 @@
+package uk.gov.dwp.queue.triage.web.server.api.status;
+
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.server.w2ui.W2UIResponse;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("api/failed-messages/status-history/{failedMessageId}")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class StatusHistoryResource {
+
+    private final FailedMessageStatusHistoryClient failedMessageStatusHistoryClient;
+
+    public StatusHistoryResource(FailedMessageStatusHistoryClient failedMessageStatusHistoryClient) {
+        this.failedMessageStatusHistoryClient = failedMessageStatusHistoryClient;
+    }
+
+    @POST
+    public W2UIResponse<StatusHistoryListItem> statusHistory(@PathParam("failedMessageId") FailedMessageId failedMessageId) {
+        return W2UIResponse.success(failedMessageStatusHistoryClient.getStatusHistory(failedMessageId)
+                        .stream()
+                        .map(StatusHistoryListItem::new)
+                        .collect(Collectors.toList())
+        );
+    }
+
+}

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
@@ -1,25 +1,26 @@
 package uk.gov.dwp.queue.triage.web.server.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.delete.DeleteFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
 import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
 import uk.gov.dwp.queue.triage.cxf.ResourceRegistry;
-import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
-import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 import uk.gov.dwp.queue.triage.web.server.api.FailedMessageChangeResource;
+import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
 import uk.gov.dwp.queue.triage.web.server.api.resend.ResendFailedMessageResource;
 import uk.gov.dwp.queue.triage.web.server.home.HomeController;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListController;
-import uk.gov.dwp.queue.triage.web.server.search.FailedMessageListItemAdapter;
-import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
-import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageController;
-import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageRequestAdapter;
 import uk.gov.dwp.queue.triage.web.server.login.AuthenticationExceptionAdapter;
 import uk.gov.dwp.queue.triage.web.server.login.LoginController;
+import uk.gov.dwp.queue.triage.web.server.search.FailedMessageListItemAdapter;
+import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageController;
+import uk.gov.dwp.queue.triage.web.server.search.SearchFailedMessageRequestAdapter;
 
 @Configuration
 @Import({
@@ -40,8 +41,9 @@ public class ControllerConfiguration {
     }
 
     @Bean
-    public FailedMessageListController failedMessageListController(ResourceRegistry resourceRegistry) {
-        return resourceRegistry.add(new FailedMessageListController());
+    public FailedMessageListController failedMessageListController(ResourceRegistry resourceRegistry,
+                                                                   @Value("${features.failedMessageDetailsPopupRendered:false}") boolean popupRendered) {
+        return resourceRegistry.add(new FailedMessageListController(popupRendered));
     }
 
     @Bean

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/ControllerConfiguration.java
@@ -8,12 +8,14 @@ import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.delete.DeleteFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
 import uk.gov.dwp.queue.triage.cxf.CxfConfiguration;
 import uk.gov.dwp.queue.triage.cxf.ResourceRegistry;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 import uk.gov.dwp.queue.triage.web.server.api.FailedMessageChangeResource;
 import uk.gov.dwp.queue.triage.web.server.api.LabelExtractor;
 import uk.gov.dwp.queue.triage.web.server.api.resend.ResendFailedMessageResource;
+import uk.gov.dwp.queue.triage.web.server.api.status.StatusHistoryResource;
 import uk.gov.dwp.queue.triage.web.server.home.HomeController;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListController;
 import uk.gov.dwp.queue.triage.web.server.login.AuthenticationExceptionAdapter;
@@ -71,5 +73,13 @@ public class ControllerConfiguration {
     public ResendFailedMessageResource resendFailedMessageResource(ResourceRegistry resourceRegistry,
                                                                    ResendFailedMessageClient resendFailedMessageClient) {
         return resourceRegistry.add(new ResendFailedMessageResource(resendFailedMessageClient));
+    }
+
+    @Bean
+    public StatusHistoryResource statusHistoryResource(ResourceRegistry resourceRegistry,
+                                                       FailedMessageStatusHistoryClient failedMessageStatusHistoryClient) {
+        return resourceRegistry.add(new StatusHistoryResource(
+                failedMessageStatusHistoryClient
+        ));
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/CoreClientConfiguration.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/configuration/CoreClientConfiguration.java
@@ -10,6 +10,7 @@ import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.delete.DeleteFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.label.LabelFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.resend.ResendFailedMessageClient;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
 
 import static java.util.Collections.singletonList;
@@ -55,6 +56,16 @@ public class CoreClientConfiguration {
         return JAXRSClientFactory.create(
                 clientProperties.getCore().getUrl(),
                 ResendFailedMessageClient.class,
+                singletonList(jacksonJsonProvider)
+        );
+    }
+
+    @Bean
+    public FailedMessageStatusHistoryClient failedMessageStatusHistoryClient(JacksonJsonProvider jacksonJsonProvider,
+                                                                             ClientProperties clientProperties) {
+        return JAXRSClientFactory.create(
+                clientProperties.getCore().getUrl(),
+                FailedMessageStatusHistoryClient.class,
                 singletonList(jacksonJsonProvider)
         );
     }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListController.java
@@ -11,10 +11,17 @@ import static javax.ws.rs.core.MediaType.TEXT_HTML;
 @Path("/failed-messages")
 public class FailedMessageListController {
 
+    private final boolean popupRendered;
+
+    public FailedMessageListController(boolean popupRendered) {
+
+        this.popupRendered = popupRendered;
+    }
+
     @GET
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_HTML)
     public FailedMessageListPage getFailedMessages() {
-        return new FailedMessageListPage();
+        return new FailedMessageListPage(popupRendered);
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItem.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItem.java
@@ -1,37 +1,51 @@
 package uk.gov.dwp.queue.triage.web.server.list;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.web.server.api.Constants;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 
 public class FailedMessageListItem {
 
-    @JsonProperty
-    private final String recid;
-    @JsonProperty
-    private final String content;
-    @JsonProperty
-    private final String broker;
-    @JsonProperty
-    private final String destination;
-    @JsonProperty
-    private final String sentDateTime;
-    @JsonProperty
-    private final String failedDateTime;
-    @JsonProperty
-    private final String labels;
+    private static final Predicate<Set<String>> IS_EMPTY = Set::isEmpty;
+    private final SearchFailedMessageResponse searchFailedMessageResponse;
 
-    public FailedMessageListItem(String recid,
-                                 String content,
-                                 String broker,
-                                 String destination,
-                                 String sentDateTime,
-                                 String failedDateTime,
-                                 String labels) {
-        this.recid = recid;
-        this.content = content;
-        this.broker = broker;
-        this.destination = destination;
-        this.sentDateTime = sentDateTime;
-        this.failedDateTime = failedDateTime;
-        this.labels = labels;
+    public FailedMessageListItem(SearchFailedMessageResponse searchFailedMessageResponse) {
+        this.searchFailedMessageResponse = searchFailedMessageResponse;
+    }
+
+    @JsonProperty("recid")
+    public String getRecId() {
+        return searchFailedMessageResponse.getFailedMessageId().toString();
+    }
+
+    public String getContent() {
+        return searchFailedMessageResponse.getContent();
+    }
+
+    public String getBroker() {
+        return searchFailedMessageResponse.getBroker();
+    }
+
+    public String getDestination() {
+        return searchFailedMessageResponse.getDestination().orElse(null);
+    }
+
+    public String getStatusDateTime() {
+        return Constants.toIsoDateTimeWithMs(searchFailedMessageResponse.getStatusDateTime()).orElse(null);
+    }
+
+    public String getStatus() {
+        return searchFailedMessageResponse.getStatus().getDescription();
+    }
+
+    public String getLabels() {
+        return Optional.ofNullable(searchFailedMessageResponse.getLabels())
+                .filter(IS_EMPTY.negate())
+                .map(x -> String.join(", ", x))
+                .orElse(null);
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListPage.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListPage.java
@@ -4,7 +4,14 @@ import uk.gov.dwp.queue.triage.web.common.Page;
 
 public class FailedMessageListPage extends Page {
 
-    public FailedMessageListPage() {
+    private final boolean popupRendered;
+
+    public FailedMessageListPage(boolean popupRendered) {
         super("list.mustache");
+        this.popupRendered = popupRendered;
+    }
+
+    public boolean isPopupRendered() {
+        return popupRendered;
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
@@ -5,31 +5,14 @@ import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItem;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static uk.gov.dwp.queue.triage.web.server.api.Constants.toIsoDateTimeWithMs;
-
 public class FailedMessageListItemAdapter {
-
-    private static final Predicate<Set<String>> IS_EMPTY = Set::isEmpty;
 
     public List<FailedMessageListItem> adapt(Collection<SearchFailedMessageResponse> failedMessages) {
         return failedMessages
                 .stream()
-                .map(fm -> new FailedMessageListItem(
-                        fm.getFailedMessageId().getId().toString(),
-                        Optional.ofNullable(fm.getContent()).map(content -> content.replace("\"", "\\\"")).orElse(null),
-                        fm.getBroker(),
-                        fm.getDestination().orElse(null),
-                        toIsoDateTimeWithMs(fm.getSentDateTime()).orElse(null),
-                        toIsoDateTimeWithMs(fm.getLastFailedDateTime()).orElse(null),
-                        Optional.ofNullable(fm.getLabels())
-                                .filter(IS_EMPTY.negate())
-                                .map(x -> String.join(", ", x))
-                                .orElse(null)))
+                .map(FailedMessageListItem::new)
                 .collect(Collectors.toList());
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/FailedMessageListItemAdapter.java
@@ -3,8 +3,6 @@ package uk.gov.dwp.queue.triage.web.server.search;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItem;
 
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -12,12 +10,10 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static java.time.ZoneOffset.UTC;
-import static java.time.format.DateTimeFormatter.ofPattern;
+import static uk.gov.dwp.queue.triage.web.server.api.Constants.toIsoDateTimeWithMs;
 
 public class FailedMessageListItemAdapter {
 
-    private static final DateTimeFormatter ISO_DATE_TIME_WITH_MS = ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(UTC);
     private static final Predicate<Set<String>> IS_EMPTY = Set::isEmpty;
 
     public List<FailedMessageListItem> adapt(Collection<SearchFailedMessageResponse> failedMessages) {
@@ -28,16 +24,12 @@ public class FailedMessageListItemAdapter {
                         Optional.ofNullable(fm.getContent()).map(content -> content.replace("\"", "\\\"")).orElse(null),
                         fm.getBroker(),
                         fm.getDestination().orElse(null),
-                        toString(fm.getSentDateTime()),
-                        toString(fm.getLastFailedDateTime()),
+                        toIsoDateTimeWithMs(fm.getSentDateTime()).orElse(null),
+                        toIsoDateTimeWithMs(fm.getLastFailedDateTime()).orElse(null),
                         Optional.ofNullable(fm.getLabels())
                                 .filter(IS_EMPTY.negate())
                                 .map(x -> String.join(", ", x))
                                 .orElse(null)))
                 .collect(Collectors.toList());
-    }
-
-    private String toString(Instant instant) {
-        return (instant != null) ? ISO_DATE_TIME_WITH_MS.format(instant) : null;
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageController.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/search/SearchFailedMessageController.java
@@ -1,13 +1,19 @@
 package uk.gov.dwp.queue.triage.web.server.search;
 
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageResponse;
 import uk.gov.dwp.queue.triage.core.client.SearchFailedMessageClient;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.web.server.list.FailedMessageListItem;
 import uk.gov.dwp.queue.triage.web.server.w2ui.W2UIResponse;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import java.util.Collection;
 
@@ -35,10 +41,14 @@ public class SearchFailedMessageController {
         Collection<SearchFailedMessageResponse> failedMessages = searchFailedMessageClient.search(
                 searchFailedMessageRequestAdapter.adapt(request)
         );
-        return new W2UIResponse<>(
-                "success",
-                failedMessages.size(),
-                failedMessageListItemAdapter.adapt(failedMessages)
-        );
+        return W2UIResponse.success(failedMessageListItemAdapter.adapt(failedMessages));
+    }
+
+    @GET
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Path("/{failedMessageId}")
+    public FailedMessageResponse getFailedMessageById(@PathParam("failedMessageId") FailedMessageId failedMessageId) {
+        return searchFailedMessageClient.getFailedMessage(failedMessageId);
     }
 }

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIDomainObject.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIDomainObject.java
@@ -1,0 +1,17 @@
+package uk.gov.dwp.queue.triage.web.server.w2ui;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public abstract class W2UIDomainObject<T> {
+
+    @JsonUnwrapped
+    protected final T object;
+
+    public W2UIDomainObject(T object) {
+        this.object = object;
+    }
+
+    @JsonProperty("recid")
+    public abstract String getRecId();
+}

--- a/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIResponse.java
+++ b/web/web-server/src/main/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIResponse.java
@@ -3,28 +3,30 @@ package uk.gov.dwp.queue.triage.web.server.w2ui;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 public class W2UIResponse<T> {
 
     @JsonProperty
-    private final String status;
-    @JsonProperty
-    private final int total;
-    @JsonProperty
     private final Collection<T> records;
 
-    public W2UIResponse(String status, int total, Collection<T> records) {
-        this.status = status;
-        this.total = total;
+    private W2UIResponse(Collection<T> records) {
         this.records = records;
     }
 
-    public String getStatus() {
-        return status;
+    public static <T> W2UIResponse<T> success(Collection<T> records) {
+        return new W2UIResponse<>(records);
     }
 
+    @JsonProperty
+    public String getStatus() {
+        return "success";
+    }
+
+    @JsonProperty
     public int getTotal() {
-        return total;
+        return Optional.ofNullable(records).orElse(Collections.emptyList()).size();
     }
 
     public Collection<T> getRecords() {

--- a/web/web-server/src/main/resources/application.yml
+++ b/web/web-server/src/main/resources/application.yml
@@ -11,3 +11,6 @@ client:
 ldap:
   urls:
     - ldap://localhost:8389/
+
+features:
+  failedMessageDetailsPopupRendered: false

--- a/web/web-server/src/main/resources/mustache/home.mustache
+++ b/web/web-server/src/main/resources/mustache/home.mustache
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8"/>
     <title>Queue Triage - Home</title>
     <link rel="stylesheet" type="text/css" href="/static/css/queue-triage.css" />
   </head>

--- a/web/web-server/src/main/resources/mustache/list.mustache
+++ b/web/web-server/src/main/resources/mustache/list.mustache
@@ -6,10 +6,14 @@
     <link rel="stylesheet" type="text/css" href="/static/css/queue-triage.css" />
     <script type="text/javascript" src="/static/js/jquery-2.1.0.min.js"></script>
     <script type="text/javascript" src="/static/js/w2ui-1.5.rc1.js"></script>
+    <script type="text/javascript" src="/static/js/test-utils.js"></script>
+    <script type="text/javascript" src="/static/js/failed-message-popup.js"></script>
 </head>
 <body>
 
-<div id="failed-message-list-grid" style="width: 100%; height: 250px;"></div>
+<div>
+    <div id="failed-message-list-grid" style="width: 100%; height: 400px;"></div>
+</div>
 
 <script type="text/javascript">
     w2utils.settings['dataType'] = 'JSON';
@@ -38,7 +42,15 @@
                 { field: 'sentDateTime', caption: 'Originally Sent', size: '160px', sortable: true },
                 { field: 'failedDateTime', caption: 'Failed', size: '160px', sortable: true },
                 { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' } },
-                { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true }
+                { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true },
+{{#popupRendered}}
+                {
+                    field: 'edit', caption: '', size: '28px',
+                    render: function (record) {
+                        return '<button class="show-more-btn w2ui-btn" onclick="displayFailedMessageDetails(\'' + record.recid + '\',\'' + record.content + '\');">...</button>';
+                    }
+                }
+{{/popupRendered}}
             ],
             onSelect: function(event) {
                 event.onComplete = function() {

--- a/web/web-server/src/main/resources/mustache/list.mustache
+++ b/web/web-server/src/main/resources/mustache/list.mustache
@@ -39,8 +39,8 @@
                 { field: 'recid', caption: 'Failed Message Id', size: '220px', sortable: true },
                 { field: 'broker', caption: 'Broker', size: '10%', sortable: true, searchable: true },
                 { field: 'destination', caption: 'Queue', size: '10%', sortable: true, searchable: true },
-                { field: 'sentDateTime', caption: 'Originally Sent', size: '160px', sortable: true },
-                { field: 'failedDateTime', caption: 'Failed', size: '160px', sortable: true },
+                { field: 'status', caption: 'Status', size: '100px', sortable: true },
+                { field: 'statusDateTime', caption: 'Status Date Time', size: '160px', sortable: true },
                 { field: 'labels', caption: 'Labels', size: '20%', editable: { type: 'text' } },
                 { field: 'content', caption: 'Content', size: '80%', sortable: true, searchable: true },
 {{#popupRendered}}

--- a/web/web-server/src/main/resources/mustache/list.mustache
+++ b/web/web-server/src/main/resources/mustache/list.mustache
@@ -2,11 +2,11 @@
 <html>
 <head>
     <title>Queue Triage - Failed Messages</title>
+    <meta charset="UTF-8"/>
     <link rel="stylesheet" type="text/css" href="/static/css/w2ui-1.5.rc1.css" />
     <link rel="stylesheet" type="text/css" href="/static/css/queue-triage.css" />
     <script type="text/javascript" src="/static/js/jquery-2.1.0.min.js"></script>
     <script type="text/javascript" src="/static/js/w2ui-1.5.rc1.js"></script>
-    <script type="text/javascript" src="/static/js/test-utils.js"></script>
     <script type="text/javascript" src="/static/js/failed-message-popup.js"></script>
 </head>
 <body>

--- a/web/web-server/src/main/resources/mustache/list.mustache
+++ b/web/web-server/src/main/resources/mustache/list.mustache
@@ -47,7 +47,7 @@
                 {
                     field: 'edit', caption: '', size: '28px',
                     render: function (record) {
-                        return '<button class="show-more-btn w2ui-btn" onclick="displayFailedMessageDetails(\'' + record.recid + '\',\'' + record.content + '\');">...</button>';
+                        return '<button class="show-more-btn w2ui-btn" onclick="displayFailedMessageDetails(\'' + record.recid + '\');">...</button>';
                     }
                 }
 {{/popupRendered}}

--- a/web/web-server/src/main/resources/mustache/login.mustache
+++ b/web/web-server/src/main/resources/mustache/login.mustache
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=9"/>
     <title>Queue Triage - Login</title>
     <link rel="stylesheet" type="text/css" href="/static/css/login.css" />

--- a/web/web-server/src/main/resources/static/css/queue-triage.css
+++ b/web/web-server/src/main/resources/static/css/queue-triage.css
@@ -47,3 +47,17 @@ body {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
 }
+
+#message-content {
+    padding: 0;
+}
+
+#message-content #content {
+    border-width: 0;
+}
+
+button.show-more-btn {
+    min-width: 20px;
+    margin: 0;
+    padding: 2px;
+}

--- a/web/web-server/src/main/resources/static/js/failed-message-popup.js
+++ b/web/web-server/src/main/resources/static/js/failed-message-popup.js
@@ -1,0 +1,118 @@
+$(function() {
+    var config = {
+        layout: {
+            name: 'layout',
+            padding: 4,
+            panels: [
+                { type: 'left', size: '50%', resizable: true, content: 'left' },
+                { type: 'main', content: 'main' },
+                { type: 'bottom', size: 250 }
+            ]
+        },
+        statusHistory: {
+            name: 'statusHistory',
+            header: 'Status History',
+            show: {
+                header: true,
+                columnHeaders: false
+            },
+            columns: [
+                { field: 'recid', caption: 'recid', hidden: true },
+                { field: 'status', caption: 'Status', size: '20%' },
+                { field: 'effectiveDate', caption: 'Effective Date', size: '80%' }
+            ]
+        },
+        messageProperties: {
+            name: 'messageProperties',
+            header: 'Properties',
+            show: {
+                header: true,
+                columnHeaders: false
+            },
+            columns: [
+                { field: 'key', caption: 'Key', size: '30%', sortable: true },
+                { field: 'value', caption: 'Value', size: '70%' }
+            ]
+        },
+        messageContent: {
+            name: 'messageContent',
+            formHTML:
+            '<div id="message-content" class="w2ui-page">'+
+            '    <div class="w2ui-field" style="height: 100%">'+
+            '        <textarea id="content" name="content" style="width: 100%; height: 100%; resize: none" />'+
+            '    </div>'+
+            '</div>'+
+            '<div class="w2ui-buttons">'+
+            '    <button id="edit" class="w2ui-btn" name="edit">Edit</button>'+
+            '    <button id="save" class="w2ui-btn w2ui-btn-green" style="display: none" name="save">Save</button>'+
+            '    <button id="cancel" class="w2ui-btn" name="cancel">Cancel</button>'+
+            '</div>',
+            header: 'Message Content',
+            fields: [
+                { field: 'content', type: 'textarea', disabled: true }
+            ],
+            record: {
+                content: '{ foo: "bar" }'
+            },
+            actions: {
+                edit: function () {
+                    var form = this;
+                    if (form.get("content").disabled) {
+                        form.get("content").disabled = false;
+                        form.refresh();
+                        document.getElementById("edit").style.display = "none";
+                        document.getElementById("save").style.display = "";
+                    } else {
+                        // Save and close popup
+                    }
+                },
+                cancel: function () {
+                    w2popup.close();
+                }
+            }
+        }
+    };
+
+    // Initialise the components
+    $().w2layout(config.layout);
+    $().w2grid(config.statusHistory);
+    $().w2grid(config.messageProperties);
+    $().w2form(config.messageContent);
+
+});
+
+function displayFailedMessageDetails(failedMessageId, content) {
+    // Populate the components with data
+
+    // Simulate the AJAX Request to get messageProperties
+    w2ui['messageProperties'].records = [
+        { recid: 1, key: 'traceId', value: 'b47befb9-1d21-4115-b6ef-588061de2bba' },
+        { recid: 2, key: 'correlationId', value: 'f6b68ddf-3bcc-4bbd-a5bf-59542f040076' },
+    ];
+    // Simulate the AJAX Request to get statusHistory
+    w2ui['statusHistory'].records = [];
+    w2ui['messageContent'].record = { "content": content };
+    w2ui['messageContent'].get('content').disabled = true;
+    // w2ui['messageContent'].refresh();
+
+    w2popup.open({
+        title   : 'Failed Message ' + failedMessageId,
+        width   : 800,
+        height  : 600,
+        showMax : true,
+        body    : '<div id="failedMessageDetails" style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px;"></div>',
+        onOpen  : function (event) {
+            event.onComplete = function () {
+                $('#w2ui-popup #main').w2render('layout');
+                w2ui.layout.content('left', w2ui['statusHistory'])
+                w2ui.layout.content('main', w2ui['messageProperties'])
+                w2ui.layout.content('bottom', w2ui['messageContent']);
+            }
+        },
+        onToggle: function (event) {
+            event.onComplete = function () {
+                w2ui.layout.resize();
+            }
+        }
+    });
+}

--- a/web/web-server/src/main/resources/static/js/w2ui-1.5.rc1.js
+++ b/web/web-server/src/main/resources/static/js/w2ui-1.5.rc1.js
@@ -1786,7 +1786,6 @@ w2utils.event = {
         if (!edata.type) { console.log('ERROR: You must specify event type when calling .on() method of '+ this.name); return; }
         if (!handler) { console.log('ERROR: You must specify event handler function when calling .on() method of '+ this.name); return; }
         if (!$.isArray(this.handlers)) this.handlers = [];
-        console.log('add', edata);
         this.handlers.push({ edata: edata, handler: handler });
     },
 

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/ConstantsTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/ConstantsTest.java
@@ -1,0 +1,22 @@
+package uk.gov.dwp.queue.triage.web.server.api;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ConstantsTest {
+
+    @Test
+    public void formatNullInstant() {
+        assertEquals(Optional.empty(), Constants.toIsoDateTimeWithMs(null));
+    }
+
+    @Test
+    public void formatGivenInstant() {
+        assertEquals(Optional.of("1970-01-01T00:00:00.000Z"), Constants.toIsoDateTimeWithMs(Instant.ofEpochMilli(0)));
+    }
+}

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryListItemTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryListItemTest.java
@@ -1,0 +1,36 @@
+package uk.gov.dwp.queue.triage.web.server.api.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
+
+public class StatusHistoryListItemTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
+    private final StatusHistoryListItem underTest = new StatusHistoryListItem(new StatusHistoryResponse(FailedMessageStatus.FAILED, Instant.EPOCH.plusMillis(1)));
+
+    @Test
+    public void serialiseToJson() throws JsonProcessingException {
+        final String json = OBJECT_MAPPER.writeValueAsString(underTest);
+        assertThat(json, allOf(
+                hasJsonPath("$.recid", equalTo("1-failed")),
+                hasJsonPath("$.status", equalTo("Failed")),
+                hasJsonPath("$.effectiveDateTime", equalTo("1970-01-01T00:00:00.001Z"))
+        ));
+    }
+
+    @Test
+    public void objectConstructedCorrectly() {
+
+    }
+}

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryResourceTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/api/status/StatusHistoryResourceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.dwp.queue.triage.web.server.api.status;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
+import uk.gov.dwp.queue.triage.core.client.status.FailedMessageStatusHistoryClient;
+import uk.gov.dwp.queue.triage.core.client.status.StatusHistoryResponse;
+import uk.gov.dwp.queue.triage.id.FailedMessageId;
+import uk.gov.dwp.queue.triage.web.server.w2ui.W2UIResponse;
+
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+
+public class StatusHistoryResourceTest {
+
+    private static final FailedMessageId FAILED_MESSAGE_ID = FailedMessageId.newFailedMessageId();
+    private static final Instant NOW = Instant.now();
+
+    @Rule
+    public MockitoRule mockitoJUnit = MockitoJUnit.rule();
+    @Mock
+    private FailedMessageStatusHistoryClient failedMessageStatusHistoryClient;
+    @InjectMocks
+    private StatusHistoryResource underTest;
+
+    @Test
+    public void adaptStatusHistoryResponseToStatusHistoryListItem() {
+        when(failedMessageStatusHistoryClient.getStatusHistory(FAILED_MESSAGE_ID)).thenReturn(Collections.singletonList(new StatusHistoryResponse(FailedMessageStatus.FAILED, NOW)));
+
+//        assertThat(underTest.statusHistory(FAILED_MESSAGE_ID), contains(statusHistoryListItem(equalTo())));
+    }
+
+    private Matcher<W2UIResponse<StatusHistoryListItem>> success(int totalResults, Matcher<Iterable<? extends StatusHistoryListItem>> results) {
+        return new TypeSafeMatcher<W2UIResponse<StatusHistoryListItem>>() {
+            @Override
+            protected boolean matchesSafely(W2UIResponse<StatusHistoryListItem> item) {
+                return "success".equals(item.getStatus());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
+    }
+
+    private Matcher<StatusHistoryListItem> statusHistoryListItem(Matcher<String> recId, Matcher<String> status, Matcher<String> effectiveDateTime) {
+        return new TypeSafeMatcher<StatusHistoryListItem>() {
+            @Override
+            protected boolean matchesSafely(StatusHistoryListItem item) {
+                return recId.matches(item.getRecId())
+                        && status.matches(item.getStatus())
+                        && effectiveDateTime.matches(item.getEffectiveDateTime());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
+    }
+}

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListControllerTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListControllerTest.java
@@ -8,12 +8,13 @@ import static org.hamcrest.Matchers.is;
 
 public class FailedMessageListControllerTest {
 
-    private final FailedMessageListController underTest = new FailedMessageListController();
+    private final FailedMessageListController underTest = new FailedMessageListController(true);
 
     @Test
     public void getFailedMessageListPage() {
         final FailedMessageListPage failedMessages = underTest.getFailedMessages();
 
         assertThat(failedMessages.getTemplate(), is(equalTo("list.mustache")));
+        assertThat(failedMessages.isPopupRendered(), is(true));
     }
 }

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListItemAdapterTest.java
@@ -3,6 +3,7 @@ package uk.gov.dwp.queue.triage.web.server.list;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import uk.gov.dwp.queue.triage.core.client.FailedMessageStatus;
 import uk.gov.dwp.queue.triage.core.client.search.SearchFailedMessageResponse;
 import uk.gov.dwp.queue.triage.id.FailedMessageId;
 import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
@@ -17,7 +18,6 @@ import java.util.HashSet;
 import java.util.UUID;
 
 import static java.time.ZoneOffset.UTC;
-import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -27,7 +27,6 @@ import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 public class FailedMessageListItemAdapterTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
-    private static final Instant EPOCH = Instant.ofEpochMilli(0);
     private static final Instant SOME_DATE_TIME = Instant.from(ZonedDateTime.of(LocalDate.of(2016, 2, 8), LocalTime.of(14, 43, 0), UTC));
     private static final String FAILED_MESSAGE_ID_1 = UUID.randomUUID().toString();
     private static final String FAILED_MESSAGE_ID_2 = UUID.randomUUID().toString();
@@ -39,16 +38,16 @@ public class FailedMessageListItemAdapterTest {
                 .withFailedMessageId(FailedMessageId.fromString(FAILED_MESSAGE_ID_1))
                 .withBroker("internal-broker")
                 .withDestination("queue-name")
-                .withSentDateTime(EPOCH)
-                .withFailedDateTime(SOME_DATE_TIME)
+                .withStatus(FailedMessageStatus.FAILED)
+                .withStatusDateTime(Instant.EPOCH)
                 .withContent("Some Content")
                 .build();
         SearchFailedMessageResponse failedMessage2 = SearchFailedMessageResponse.newSearchFailedMessageResponse()
                 .withFailedMessageId(FailedMessageId.fromString(FAILED_MESSAGE_ID_2))
                 .withBroker("internal-broker")
                 .withDestination("another-queue")
-                .withSentDateTime(SOME_DATE_TIME)
-                .withFailedDateTime(SOME_DATE_TIME.with(MILLI_OF_SECOND, 123))
+                .withStatus(FailedMessageStatus.RESENDING)
+                .withStatusDateTime(SOME_DATE_TIME)
                 .withContent("More Content")
                 .withLabels(new HashSet<>(Arrays.asList("aaa","bbb")))
                 .build();
@@ -60,16 +59,16 @@ public class FailedMessageListItemAdapterTest {
                 hasJsonPath("$.[0].broker", equalTo("internal-broker")),
                 hasJsonPath("$.[0].content", equalTo("Some Content")),
                 hasJsonPath("$.[0].destination", equalTo("queue-name")),
-                hasJsonPath("$.[0].sentDateTime", equalTo("1970-01-01T00:00:00.000Z")),
-                hasJsonPath("$.[0].failedDateTime", equalTo("2016-02-08T14:43:00.000Z")),
+                hasJsonPath("$.[0].status", equalTo("Failed")),
+                hasJsonPath("$.[0].statusDateTime", equalTo("1970-01-01T00:00:00.000Z")),
                 hasJsonPath("$.[0].labels", nullValue()),
 
                 hasJsonPath("$.[1].recid", equalTo(FAILED_MESSAGE_ID_2)),
                 hasJsonPath("$.[1].broker", equalTo("internal-broker")),
                 hasJsonPath("$.[1].content", equalTo("More Content")),
                 hasJsonPath("$.[1].destination", equalTo("another-queue")),
-                hasJsonPath("$.[1].sentDateTime", equalTo("2016-02-08T14:43:00.000Z")),
-                hasJsonPath("$.[1].failedDateTime", equalTo("2016-02-08T14:43:00.123Z")),
+                hasJsonPath("$.[1].status", equalTo("Resending")),
+                hasJsonPath("$.[1].statusDateTime", equalTo("2016-02-08T14:43:00.000Z")),
                 hasJsonPath("$.[1].labels", equalTo("aaa, bbb"))
         ));
     }

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListPageTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/list/FailedMessageListPageTest.java
@@ -1,0 +1,17 @@
+package uk.gov.dwp.queue.triage.web.server.list;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FailedMessageListPageTest {
+
+    @Test
+    public void createFailedMessageListPage() {
+        FailedMessageListPage underTest = new FailedMessageListPage(true);
+
+        assertTrue(underTest.isPopupRendered());
+        assertEquals("list.mustache", underTest.getTemplate());
+    }
+}

--- a/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIResponseTest.java
+++ b/web/web-server/src/test/java/uk/gov/dwp/queue/triage/web/server/w2ui/W2UIResponseTest.java
@@ -1,0 +1,39 @@
+package uk.gov.dwp.queue.triage.web.server.w2ui;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.dwp.queue.triage.jackson.configuration.JacksonConfiguration;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
+
+public class W2UIResponseTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonConfiguration().objectMapper();
+    private final W2UIResponse<String> underTest = W2UIResponse.success(Arrays.asList("foo", "bar"));
+
+    @Test
+    public void serialiseW2UIResponseWithSimpleType() throws JsonProcessingException {
+        final String json = OBJECT_MAPPER.writeValueAsString(underTest);
+
+        assertThat(json, allOf(
+                hasJsonPath("$.status", equalTo("success")),
+                hasJsonPath("$.total", equalTo(2)),
+                hasJsonPath("$.records", contains("foo", "bar"))
+        ));
+    }
+
+    @Test
+    public void objectConstructedCorrectly() {
+        assertEquals("success", underTest.getStatus());
+        assertEquals(2, underTest.getTotal());
+        assertEquals(Arrays.asList("foo", "bar"), underTest.getRecords());
+    }
+}


### PR DESCRIPTION
Added a modal dialog to display the status history and allow users to edit message properties, the destination (and broker) and the message content.

This functionality is currently behind a feature toggle and can be enabled by either updating the `failedMessageDetailsPopupRendered` property in the `application.yml` to `true` or by starting the web-server with the following VM option `-Dfeatures.failedMessageDetailsPopupRendered=true`