### PR TITLE
#87: Improved test coverage of AuditMongoCollection

### DIFF
--- a/core/dao-mongo/dao-mongo.gradle
+++ b/core/dao-mongo/dao-mongo.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation 'org.hibernate:hibernate-validator'
     testImplementation 'org.jboss.logging:jboss-logging'
     testImplementation 'com.fasterxml:classmate:1.3.3'
+    testImplementation 'uk.org.lidalia:slf4j-test'
 
     testImplementation 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     testImplementation 'org.springframework.boot:spring-boot-test'

--- a/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/AuditingMongoCollection.java
+++ b/core/dao-mongo/src/main/java/uk/gov/dwp/queue/triage/core/dao/mongo/AuditingMongoCollection.java
@@ -39,6 +39,22 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Writes an audit document to a separate collection in the format:
+ * <pre>
+ * {
+ *   "_id" : ObjectId("5af56fc30b41674d8030c9b0"),
+ *    "auditAction" : "INSERT",
+ *    "auditDateTime" : ISODate("2018-05-11T10:26:11.666Z"),
+ *    "document" : {
+ *      "_id" : "e30eaa4a-4700-4a37-a771-dac30eddbd45",
+ *      ...
+ *    }
+ * }
+ * </pre>
+ * NOTE: At this time certain operations are NOT audited (as they are not used by the application), if an operation that
+ * is not audited is executed a message will be written to the application logs at level WARN
+ */
 public class AuditingMongoCollection implements MongoCollection<Document> {
 
     static final String AUDIT_ACTION_KEY = "auditAction";
@@ -50,7 +66,7 @@ public class AuditingMongoCollection implements MongoCollection<Document> {
     static final String REPLACE_AUDIT_ACTION = "REPLACE";
     static final String UPDATE_AUDIT_ACTION = "UPDATE";
 
-    private static Logger LOGGER = LoggerFactory.getLogger(AuditingMongoCollection.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditingMongoCollection.class);
 
     private final MongoCollection<Document> sourceCollection;
     private final MongoCollection<Document> auditCollection;
@@ -183,13 +199,13 @@ public class AuditingMongoCollection implements MongoCollection<Document> {
 
     @Override
     public BulkWriteResult bulkWrite(List<? extends WriteModel<? extends Document>> requests) {
-        LOGGER.warn("bulkWrite operation is not currently audited");
+        warnOperationNotAudited("bulkWrite");
         return sourceCollection.bulkWrite(requests);
     }
 
     @Override
     public BulkWriteResult bulkWrite(List<? extends WriteModel<? extends Document>> requests, BulkWriteOptions options) {
-        LOGGER.warn("bulkWrite operation is not currently audited");
+        warnOperationNotAudited("bulkWrite with options");
         return sourceCollection.bulkWrite(requests, options);
     }
 
@@ -317,73 +333,73 @@ public class AuditingMongoCollection implements MongoCollection<Document> {
 
     @Override
     public UpdateResult updateMany(Bson filter, Bson update) {
-        LOGGER.warn("updateMany operation is not currently audited");
+        warnOperationNotAudited("updateMany");
         return sourceCollection.updateMany(filter, update);
     }
 
     @Override
     public UpdateResult updateMany(Bson filter, Bson update, UpdateOptions updateOptions) {
-        LOGGER.warn("updateMany with UpdateOptions operation is not currently audited");
+        warnOperationNotAudited("updateMany with options");
         return sourceCollection.updateMany(filter, update, updateOptions);
     }
 
     @Override
     public Document findOneAndDelete(Bson filter) {
-        LOGGER.warn("findOneAndDelete operation is not currently audited");
+        warnOperationNotAudited("findOneAndDelete");
         return sourceCollection.findOneAndDelete(filter);
     }
 
     @Override
     public Document findOneAndDelete(Bson filter, FindOneAndDeleteOptions options) {
-        LOGGER.warn("findOneAndDelete operation is not currently audited");
+        warnOperationNotAudited("findOneAndDelete with options");
         return sourceCollection.findOneAndDelete(filter, options);
     }
 
     @Override
     public Document findOneAndReplace(Bson filter, Document replacement) {
-        LOGGER.warn("findOneAndReplace operation is not currently audited");
+        warnOperationNotAudited("findOneAndReplace");
         return sourceCollection.findOneAndReplace(filter, replacement);
     }
 
     @Override
     public Document findOneAndReplace(Bson filter, Document replacement, FindOneAndReplaceOptions options) {
-        LOGGER.warn("findOneAndReplace operation is not currently audited");
+        warnOperationNotAudited("findOneAndReplace with options");
         return sourceCollection.findOneAndReplace(filter, replacement, options);
     }
 
     @Override
     public Document findOneAndUpdate(Bson filter, Bson update) {
-        LOGGER.warn("findOneAndUpdate operation is not currently audited");
+        warnOperationNotAudited("findOneAndUpdate");
         return sourceCollection.findOneAndUpdate(filter, update);
     }
 
     @Override
     public Document findOneAndUpdate(Bson filter, Bson update, FindOneAndUpdateOptions options) {
-        LOGGER.warn("findOneAndUpdate operation is not currently audited");
+        warnOperationNotAudited("findOneAndUpdate with options");
         return sourceCollection.findOneAndUpdate(filter, update, options);
     }
 
     @Override
     public void drop() {
-        LOGGER.warn("drop operation is not currently audited");
+        warnOperationNotAudited("drop");
         sourceCollection.drop();
     }
 
     @Override
     public String createIndex(Bson keys) {
-        LOGGER.warn("createIndex operation is not currently audited");
+        warnOperationNotAudited("createIndex");
         return sourceCollection.createIndex(keys);
     }
 
     @Override
     public String createIndex(Bson keys, IndexOptions indexOptions) {
-        LOGGER.warn("createIndex operation is not currently audited");
+        warnOperationNotAudited("createIndex with options");
         return sourceCollection.createIndex(keys, indexOptions);
     }
 
     @Override
     public List<String> createIndexes(List<IndexModel> indexes) {
-        LOGGER.warn("createIndex operation is not currently audited");
+        warnOperationNotAudited("createIndexes");
         return sourceCollection.createIndexes(indexes);
     }
 
@@ -399,31 +415,35 @@ public class AuditingMongoCollection implements MongoCollection<Document> {
 
     @Override
     public void dropIndex(String indexName) {
-        LOGGER.warn("dropIndex(indexName) operation is not currently audited");
+        warnOperationNotAudited("dropIndex with name");
         sourceCollection.dropIndex(indexName);
     }
 
     @Override
     public void dropIndex(Bson keys) {
-        LOGGER.warn("dropIndex(keys) operation is not currently audited");
+        warnOperationNotAudited("dropIndex with keys");
         sourceCollection.dropIndex(keys);
     }
 
     @Override
     public void dropIndexes() {
-        LOGGER.warn("dropIndexes operation is not currently audited");
+        warnOperationNotAudited("dropIndexes");
         sourceCollection.dropIndexes();
     }
 
     @Override
     public void renameCollection(MongoNamespace newCollectionNamespace) {
-        LOGGER.warn("renameCollection operation is not currently audited");
+        warnOperationNotAudited("renameCollection");
         sourceCollection.renameCollection(newCollectionNamespace);
     }
 
     @Override
     public void renameCollection(MongoNamespace newCollectionNamespace, RenameCollectionOptions renameCollectionOptions) {
-        LOGGER.warn("renameCollection operation is not currently audited");
+        warnOperationNotAudited("renameCollection with options");
         sourceCollection.renameCollection(newCollectionNamespace, renameCollectionOptions);
+    }
+
+    protected void warnOperationNotAudited(String operation) {
+        LOGGER.warn("{} operation is not currently audited", operation);
     }
 }

--- a/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/AuditingMongoCollectionDelegationTest.java
+++ b/core/dao-mongo/src/test/java/uk/gov/dwp/queue/triage/core/dao/mongo/AuditingMongoCollectionDelegationTest.java
@@ -1,0 +1,405 @@
+package uk.gov.dwp.queue.triage.core.dao.mongo;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.RenameCollectionOptions;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.warn;
+
+/**
+ * The purpose of this test to record (and document) the fact that certain operations are not (yet) audited.
+ */
+public class AuditingMongoCollectionDelegationTest {
+
+    @Rule
+    public MockitoRule mockitoJUnit = MockitoJUnit.rule();
+    @Mock
+    private MongoCollection<Document> auditCollection;
+    @Mock
+    private MongoCollection<Document> sourceCollection;
+    @Mock
+    private Bson filter;
+    @Mock
+    private Document document;
+    @Mock
+    private Bson keys;
+    private TestLogger logger = TestLoggerFactory.getTestLogger(AuditingMongoCollection.class);
+
+    private AuditingMongoCollection underTest;
+
+    @Before
+    public void setUp() { ;
+        underTest = new AuditingMongoCollection(sourceCollection, auditCollection);
+    }
+
+    @After
+    public void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void getNamespace() {
+        underTest.getNamespace();
+        verify(sourceCollection).getNamespace();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void getDocumentClass() {
+        underTest.getDocumentClass();
+        verify(sourceCollection).getDocumentClass();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void getCodecRegistry() {
+        underTest.getCodecRegistry();
+
+        verify(sourceCollection).getCodecRegistry();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void getReadPreference() {
+        underTest.getReadPreference();
+
+        verify(sourceCollection).getReadPreference();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void getWriteConcern() {
+        underTest.getWriteConcern();
+
+        verify(sourceCollection).getWriteConcern();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void getReadConcern() {
+        underTest.getReadConcern();
+
+        verify(sourceCollection).getReadConcern();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void withDocumentClass() {
+        underTest.withDocumentClass(Number.class);
+
+        verify(sourceCollection).withDocumentClass(Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void withCodecRegistry() {
+        final CodecRegistry codecRegistry = mock(CodecRegistry.class);
+
+        underTest.withCodecRegistry(codecRegistry);
+
+        verify(sourceCollection).withCodecRegistry(codecRegistry);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void count() {
+        underTest.count();
+
+        verify(sourceCollection).count();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void countWithFilter() {
+        underTest.count(document);
+
+        verify(sourceCollection).count(document);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void countWithFilterAndOptions() {
+        CountOptions countOptions = mock(CountOptions.class);
+
+        underTest.count(document, countOptions);
+
+        verify(sourceCollection).count(document, countOptions);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void distinct() {
+        underTest.distinct("foo", Number.class);
+
+        verify(sourceCollection).distinct("foo", Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void distinctWithFilter() {
+        underTest.distinct("foo", filter, Number.class);
+
+        verify(sourceCollection).distinct("foo", filter, Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void find() {
+        underTest.find();
+
+        verify(sourceCollection).find();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void findWithResultClass() {
+        underTest.find(Number.class);
+
+        verify(sourceCollection).find(Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void findNumberWithFilter() {
+        underTest.find(filter);
+
+        verify(sourceCollection).find(filter);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void findWithFilterAndResultClass() {
+        underTest.find(filter, Number.class);
+
+        verify(sourceCollection).find(filter, Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void aggregateWithPipeline() {
+        underTest.aggregate(Collections.emptyList());
+
+        verify(sourceCollection).aggregate(Collections.emptyList());
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void aggregateWithPipelineAndResultClass() {
+        underTest.aggregate(Collections.emptyList(), Number.class);
+
+        verify(sourceCollection).aggregate(Collections.emptyList(), Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void mapReduce() {
+        underTest.mapReduce("map", "reduce");
+
+        verify(sourceCollection).mapReduce("map", "reduce");
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void mapReduceResultClass() {
+        underTest.mapReduce("map", "reduce", Number.class);
+
+        verify(sourceCollection).mapReduce("map", "reduce", Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void bulkWrite() {
+        underTest.bulkWrite(Collections.emptyList());
+
+        verify(sourceCollection).bulkWrite(Collections.emptyList());
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "bulkWrite")));
+    }
+
+    @Test
+    public void bulkWriteWithOptions() {
+        BulkWriteOptions bulkWriteOptions = mock(BulkWriteOptions.class);
+        underTest.bulkWrite(Collections.emptyList(), bulkWriteOptions);
+
+        verify(sourceCollection).bulkWrite(Collections.emptyList(), bulkWriteOptions);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "bulkWrite with options")));
+    }
+
+    @Test
+    public void updateMany() {
+        underTest.updateMany(filter, document);
+
+        verify(sourceCollection).updateMany(filter, document);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "updateMany")));
+    }
+
+    @Test
+    public void findOneAndDeleteWithFilter() {
+        underTest.findOneAndDelete(filter);
+
+        verify(sourceCollection).findOneAndDelete(filter);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "findOneAndDelete")));
+    }
+
+    @Test
+    public void findOneAndDeleteWithFilterAndOptions() {
+        final FindOneAndDeleteOptions findOneAndDeleteOptions = mock(FindOneAndDeleteOptions.class);
+
+        underTest.findOneAndDelete(filter, findOneAndDeleteOptions);
+
+        verify(sourceCollection).findOneAndDelete(filter, findOneAndDeleteOptions);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "findOneAndDelete with options")));
+    }
+
+    @Test
+    public void findOneAndReplaceWithFilter() {
+        underTest.findOneAndReplace(filter, document);
+
+        verify(sourceCollection).findOneAndReplace(filter, document);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "findOneAndReplace")));
+    }
+
+    @Test
+    public void findOneAndReplaceWithFilterAndOptions() {
+        final FindOneAndReplaceOptions findOneAndReplaceOptions = mock(FindOneAndReplaceOptions.class);
+
+        underTest.findOneAndReplace(filter, document, findOneAndReplaceOptions);
+
+        verify(sourceCollection).findOneAndReplace(filter, document, findOneAndReplaceOptions);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "findOneAndReplace with options")));
+    }
+
+    @Test
+    public void drop() {
+        underTest.drop();
+
+        verify(sourceCollection).drop();
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "drop")));
+    }
+
+    @Test
+    public void createIndex() {
+        underTest.createIndex(keys);
+
+        verify(sourceCollection).createIndex(keys);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "createIndex")));
+    }
+
+    @Test
+    public void createIndexWithOptions() {
+        final IndexOptions indexOptions = mock(IndexOptions.class);
+
+        underTest.createIndex(keys, indexOptions);
+
+        verify(sourceCollection).createIndex(keys, indexOptions);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "createIndex with options")));
+    }
+
+    @Test
+    public void createIndexes() {
+        underTest.createIndexes(Collections.emptyList());
+
+        verify(sourceCollection).createIndexes(Collections.emptyList());
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "createIndexes")));
+    }
+
+    @Test
+    public void listIndexes() {
+        underTest.listIndexes();
+
+        verify(sourceCollection).listIndexes();
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void listIndexesWithResultClass() {
+        underTest.listIndexes(Number.class);
+
+        verify(sourceCollection).listIndexes(Number.class);
+        verifyZeroInteractions(auditCollection);
+    }
+
+    @Test
+    public void dropIndex() {
+        underTest.dropIndex("index-name");
+
+        verify(sourceCollection).dropIndex("index-name");
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "dropIndex with name")));
+    }
+
+    @Test
+    public void dropIndexWithKeys() {
+        underTest.dropIndex(keys);
+
+        verify(sourceCollection).dropIndex(keys);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "dropIndex with keys")));
+    }
+
+    @Test
+    public void dropIndexes() {
+        underTest.dropIndexes();
+
+        verify(sourceCollection).dropIndexes();
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "dropIndexes")));
+    }
+
+    @Test
+    public void renameCollection() {
+        final MongoNamespace newCollectionNamespace = mock(MongoNamespace.class);
+
+        underTest.renameCollection(newCollectionNamespace);
+
+        verify(sourceCollection).renameCollection(newCollectionNamespace);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "renameCollection")));
+    }
+
+    @Test
+    public void renameCollectionWithOptions() {
+        final MongoNamespace newCollectionNamespace = mock(MongoNamespace.class);
+        final RenameCollectionOptions renameCollectionOptions = mock(RenameCollectionOptions.class);
+
+        underTest.renameCollection(newCollectionNamespace, renameCollectionOptions);
+
+        verify(sourceCollection).renameCollection(newCollectionNamespace, renameCollectionOptions);
+        verifyZeroInteractions(auditCollection);
+        assertThat(logger.getLoggingEvents(), contains(warn("{} operation is not currently audited", "renameCollection with options")));
+    }
+}

--- a/core/dao-mongo/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/dao-mongo/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionRegistryPostProcessor.java
+++ b/core/resend/src/main/java/uk/gov/dwp/queue/triage/core/resend/spring/ResendBeanDefinitionRegistryPostProcessor.java
@@ -24,6 +24,7 @@ public class ResendBeanDefinitionRegistryPostProcessor implements BeanDefinition
     private final JmsTemplateBeanDefinitionFactory jmsTemplateBeanDefinitionFactory;
     private final ResendScheduledExecutorServiceBeanDefinitionFactory resendScheduledExecutorServiceBeanDefinitionFactory;
 
+    // CHECKSTYLE:OFF
     public ResendBeanDefinitionRegistryPostProcessor(Environment environment,
                                                      ActiveMQConnectionFactoryFactoryBeanDefinitionFactory activeMQConnectionFactoryFactoryBeanDefinitionFactory,
                                                      ActiveMQConnectionFactoryBeanDefinitionFactory activeMQConnectionFactoryBeanDefinitionFactory,
@@ -32,6 +33,7 @@ public class ResendBeanDefinitionRegistryPostProcessor implements BeanDefinition
                                                      SpringMessageSenderBeanDefinitionFactory springMessageSenderBeanDefinitionFactory,
                                                      JmsTemplateBeanDefinitionFactory jmsTemplateBeanDefinitionFactory,
                                                      ResendScheduledExecutorServiceBeanDefinitionFactory resendScheduledExecutorServiceBeanDefinitionFactory) {
+    // CHECKSTYLE:ON
         this.environment = environment;
         this.activeMQConnectionFactoryFactoryBeanDefinitionFactory = activeMQConnectionFactoryFactoryBeanDefinitionFactory;
         this.activeMQConnectionFactoryBeanDefinitionFactory = activeMQConnectionFactoryBeanDefinitionFactory;

--- a/dependency_config.gradle
+++ b/dependency_config.gradle
@@ -168,6 +168,8 @@ subprojects {
             dependency 'org.objenesis:objenesis:2.5.1'
             dependency 'org.valid4j:json-path-matchers:1.1'
             dependency 'org.yaml:snakeyaml:1.17'
+            dependency 'uk.org.lidalia:slf4j-test:1.1.0'
+
         }
     }
 }


### PR DESCRIPTION
- assert readOnly operations delegate to the `sourceCollection` and do not interact with the `auditCollection`
- assert log warning message for write operations that are not currently audited (these are not used by `FailedMessageDao`